### PR TITLE
docs: add Juggle logo and refresh README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
-# Juggle
+<div align="center">
 
-Claude Code can only hold one conversation at a time. You're designing an auth module, you need to look up rate-limiting best practices, and you want to check an env var config, but each detour blows away the context you've been building. You either serialize everything or lose your train of thought.
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/juggle-logo-dark.svg">
+  <img src="docs/assets/juggle-logo.svg" alt="Juggle" width="380">
+</picture>
+
+**Parallel conversation threads for Claude Code.**
+
+[![Version](https://img.shields.io/badge/version-1.15.0-2563eb.svg)](.claude-plugin/plugin.json)
+[![Python](https://img.shields.io/badge/python-3.12+-f59e0b.svg)](https://www.python.org/)
+[![tmux](https://img.shields.io/badge/tmux-3.0+-22c55e.svg)](https://github.com/tmux/tmux)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-94a3b8.svg)](#prerequisites)
+
+</div>
+
+<!--
+  SCREENSHOT SUGGESTION #1 — Hero demo GIF
+  Place a 10–15s animated GIF here showing: user types a multi-topic prompt,
+  Juggle spins up a second thread + tmux pane, and the cockpit reflects the
+  new agent. Suggested filename: docs/assets/screenshots/hero-demo.gif
+  Embed with:  ![Juggle in action](docs/assets/screenshots/hero-demo.gif)
+-->
+
+---
+
+Claude Code can only hold one conversation at a time. You're designing an auth module, you need to look up rate-limiting best practices, and you want to check an env var config — but each detour blows away the context you've been building. You either serialize everything or lose your train of thought.
 
 Juggle fixes this. It gives Claude Code parallel conversation threads backed by persistent memory, so you can work on multiple topics simultaneously without losing context on any of them.
+
+## Table of Contents
+
+- [How it works](#how-it-works-in-practice)
+- [Key capabilities](#key-capabilities)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Architecture](#architecture)
+- [Install](#install)
+- [Commands](#commands)
+- [Cockpit](#cockpit)
+- [State Management](#state-management)
+- [Configuration](#configuration-reference)
+- [Troubleshooting](#troubleshooting)
+- [Roadmap](#roadmap)
 
 ### How it works in practice
 
@@ -15,9 +54,23 @@ You're building a feature and hit a question about API rate limits. Instead of d
 
 No copy-pasting prompts. No "where was I?" after a tangent. Just type naturally and let Juggle manage the concurrency.
 
+<!--
+  SCREENSHOT SUGGESTION #2 — Topic-shift detection
+  A still terminal capture showing the orchestrator detecting a topic shift
+  and announcing the new thread label (e.g. "[B] API rate limiting").
+  Suggested filename: docs/assets/screenshots/topic-shift.png
+-->
+
 ### Key capabilities
 
 **Background agents via tmux.** Dispatch research, code generation, or analysis to background agents running in tmux panes. They work in parallel while your main conversation continues uninterrupted. Up to 20 concurrent agents.
+
+<!--
+  SCREENSHOT SUGGESTION #3 — tmux pane grid with agents
+  Capture the "juggle" tmux session attached, showing 3–4 active agent panes
+  each running Claude Code. Use `tmux attach -t juggle` to capture.
+  Suggested filename: docs/assets/screenshots/tmux-agents.png
+-->
 
 **Persistent multi-topic threads.** Every thread is stored in SQLite with full message history. Session compactions, restarts, and context window limits don't erase your work. Pick up any topic exactly where you left off.
 
@@ -147,6 +200,15 @@ Under the hood every command shells out to `python3 ${CLAUDE_PLUGIN_ROOT}/src/ju
 
 A live terminal dashboard for the current juggle session. Read-only — it never writes to the DB.
 
+<!--
+  SCREENSHOT SUGGESTION #4 — Cockpit live view
+  A high-resolution still of the running cockpit (Topics / Action Items / Agents
+  columns + Notifications strip). Capture from a real session with 3+ topics
+  and at least one running agent so the glyph legend is visible.
+  Suggested filename: docs/assets/screenshots/cockpit.png
+  Place ABOVE the ASCII mockup so the mockup serves as a fallback / legend.
+-->
+
 **Launch:**
 
 ```bash
@@ -193,6 +255,13 @@ Refreshes once per second (configurable via `cockpit.refresh_interval_secs`). Ex
 | 📌 | Action item, normal priority |
 
 ## Topic Status Display
+
+<!--
+  SCREENSHOT SUGGESTION #5 — `/juggle:show-topics` output
+  Capture a real terminal showing the output of `/juggle:show-topics` with
+  a mix of active, running, and done topics. Useful to demo the CLI surface.
+  Suggested filename: docs/assets/screenshots/show-topics.png
+-->
 
 ```
 Topics:

--- a/docs/assets/juggle-icon.svg
+++ b/docs/assets/juggle-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="Juggle">
+  <title>Juggle</title>
+  <!-- Motion arcs (juggling trajectories) -->
+  <g fill="none" stroke-linecap="round" stroke-dasharray="3 7" opacity="0.45">
+    <path d="M 56 196 C 80 56, 128 56, 152 196" stroke="#F97316" stroke-width="3"/>
+    <path d="M 104 196 C 128 24, 176 24, 200 196" stroke="#8B5CF6" stroke-width="3"/>
+    <path d="M 56 196 C 96 84, 160 84, 200 196" stroke="#06B6D4" stroke-width="3"/>
+  </g>
+
+  <!-- Three balls (one per topic / thread) -->
+  <circle cx="104" cy="80" r="22" fill="#F97316"/>
+  <circle cx="152" cy="44" r="22" fill="#8B5CF6"/>
+  <circle cx="200" cy="92" r="22" fill="#06B6D4"/>
+
+  <!-- Soft highlights -->
+  <circle cx="98" cy="74" r="6" fill="#ffffff" opacity="0.4"/>
+  <circle cx="146" cy="38" r="6" fill="#ffffff" opacity="0.4"/>
+  <circle cx="194" cy="86" r="6" fill="#ffffff" opacity="0.4"/>
+
+  <!-- Catch points (juggler's hands) -->
+  <circle cx="56" cy="196" r="5" fill="#94A3B8"/>
+  <circle cx="200" cy="196" r="5" fill="#94A3B8"/>
+</svg>

--- a/docs/assets/juggle-logo-dark.svg
+++ b/docs/assets/juggle-logo-dark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="180" viewBox="0 0 640 180" role="img" aria-label="Juggle">
+  <title>Juggle</title>
+
+  <!-- Icon -->
+  <g transform="translate(8 -22) scale(0.78)">
+    <g fill="none" stroke-linecap="round" stroke-dasharray="3 7" opacity="0.55">
+      <path d="M 56 196 C 80 56, 128 56, 152 196" stroke="#FB923C" stroke-width="3"/>
+      <path d="M 104 196 C 128 24, 176 24, 200 196" stroke="#A78BFA" stroke-width="3"/>
+      <path d="M 56 196 C 96 84, 160 84, 200 196" stroke="#22D3EE" stroke-width="3"/>
+    </g>
+    <circle cx="104" cy="80" r="22" fill="#FB923C"/>
+    <circle cx="152" cy="44" r="22" fill="#A78BFA"/>
+    <circle cx="200" cy="92" r="22" fill="#22D3EE"/>
+    <circle cx="98" cy="74" r="6" fill="#ffffff" opacity="0.5"/>
+    <circle cx="146" cy="38" r="6" fill="#ffffff" opacity="0.5"/>
+    <circle cx="194" cy="86" r="6" fill="#ffffff" opacity="0.5"/>
+    <circle cx="56" cy="196" r="5" fill="#CBD5E1"/>
+    <circle cx="200" cy="196" r="5" fill="#CBD5E1"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="220" y="118"
+        font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
+        font-size="104" font-weight="700" letter-spacing="-4"
+        fill="#F1F5F9">juggle</text>
+</svg>

--- a/docs/assets/juggle-logo.svg
+++ b/docs/assets/juggle-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="180" viewBox="0 0 640 180" role="img" aria-label="Juggle">
+  <title>Juggle</title>
+
+  <!-- Icon -->
+  <g transform="translate(8 -22) scale(0.78)">
+    <g fill="none" stroke-linecap="round" stroke-dasharray="3 7" opacity="0.45">
+      <path d="M 56 196 C 80 56, 128 56, 152 196" stroke="#F97316" stroke-width="3"/>
+      <path d="M 104 196 C 128 24, 176 24, 200 196" stroke="#8B5CF6" stroke-width="3"/>
+      <path d="M 56 196 C 96 84, 160 84, 200 196" stroke="#06B6D4" stroke-width="3"/>
+    </g>
+    <circle cx="104" cy="80" r="22" fill="#F97316"/>
+    <circle cx="152" cy="44" r="22" fill="#8B5CF6"/>
+    <circle cx="200" cy="92" r="22" fill="#06B6D4"/>
+    <circle cx="98" cy="74" r="6" fill="#ffffff" opacity="0.4"/>
+    <circle cx="146" cy="38" r="6" fill="#ffffff" opacity="0.4"/>
+    <circle cx="194" cy="86" r="6" fill="#ffffff" opacity="0.4"/>
+    <circle cx="56" cy="196" r="5" fill="#94A3B8"/>
+    <circle cx="200" cy="196" r="5" fill="#94A3B8"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="220" y="118"
+        font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
+        font-size="104" font-weight="700" letter-spacing="-4"
+        fill="#0F172A">juggle</text>
+</svg>


### PR DESCRIPTION
## Summary

- New SVG logo set under `docs/assets/` (icon + horizontal wordmark in light & dark variants). Concept: three balls in a juggling cascade, one per parallel thread — directly maps to Juggle's multi-topic story.
- README header refreshed: theme-aware `<picture>` logo, tagline, shields badges (version, Python, tmux, platform), and a table of contents.
- Five inline screenshot placeholder comments mark the recommended capture spots so they can be dropped in later without hunting for the right location.

## Logo files

| File | Purpose |
|---|---|
| `docs/assets/juggle-icon.svg` | 256×256 square icon (favicons, plugin tile) |
| `docs/assets/juggle-logo.svg` | Horizontal logo, dark wordmark (light backgrounds) |
| `docs/assets/juggle-logo-dark.svg` | Horizontal logo, light wordmark (dark backgrounds) |

The `<picture>` element in the README auto-swaps based on `prefers-color-scheme`.

## Suggested screenshot locations

Each is marked in the README with an HTML comment block (`SCREENSHOT SUGGESTION #N`) so it's discoverable from a grep:

1. **Hero demo GIF** — top of README, just under the badges. 10–15 s capture of typing a multi-topic prompt → second thread spins up → cockpit reflects the new agent. *(`docs/assets/screenshots/hero-demo.gif`)*
2. **Topic-shift detection** — under "How it works in practice." Still showing the orchestrator opening a new labelled thread. *(`topic-shift.png`)*
3. **tmux agent grid** — under "Background agents via tmux." `tmux attach -t juggle` capture with 3–4 agent panes. *(`tmux-agents.png`)*
4. **Cockpit live view** — top of the Cockpit section, above the existing ASCII mockup so the mockup serves as a fallback/legend. *(`cockpit.png`)*
5. **`/juggle:show-topics` output** — Topic Status Display section. Real terminal output mixing active / running / done topics. *(`show-topics.png`)*

## Test plan

- [ ] Render README in GitHub light theme — verify logo, badges, TOC display correctly
- [ ] Render README in GitHub dark theme — verify dark logo variant kicks in via `<picture>`
- [ ] Open `docs/assets/juggle-icon.svg` directly in a browser at small sizes (favicon-scale)
- [ ] Confirm TOC anchors resolve to the correct sections
- [ ] (Follow-up) Capture and drop in screenshots at the five marked locations

https://claude.ai/code/session_01SY72qgBMdvPpRWfbHbxqEz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY72qgBMdvPpRWfbHbxqEz)_