### PR TITLE
feat: enforce autopilot via hook; fix stale agent instructions & doc paths

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "juggle",
   "description": "Multi-topic conversation orchestrator. Manage parallel conversation threads within a single Claude Code session \u2014 discuss one topic while background agents research or build for others.",
-  "version": "1.35.1",
+  "version": "1.36.0",
   "author": {
     "name": "Mike Chen"
   },

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,6 @@
 # Project Context
 
-This is a javascript project using raw-http.
-
+Python CLI project (Claude Code plugin). Source in `src/`.
 
 Required environment variables (no defaults):
 - _JUGGLE_TEST_DB (src/juggle_cli.py)
@@ -9,5 +8,6 @@ Required environment variables (no defaults):
 - JUGGLE_MAX_BACKGROUND_AGENTS (src/juggle_db.py)
 - JUGGLE_MAX_THREADS (src/juggle_db.py)
 
-Read .codesight/wiki/index.md for orientation (WHERE things live). Then read actual source files before implementing. Wiki articles are navigation aids, not implementation guides.
-Read .codesight/CODESIGHT.md for the complete AI context map including all routes, schema, components, libraries, config, middleware, and dependency graph.
+Read graphify-out/GRAPH_REPORT.md for orientation — god nodes and community structure show WHERE things live. Then read the actual source files in src/ before implementing. The graph is a navigation aid, not an implementation guide.
+
+See CLAUDE.md for the full design philosophy, versioning, and task-tracking conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # Project Context
 
-This is a javascript project using raw-http.
-
+Python CLI project (Claude Code plugin). Source in `src/`.
 
 Required environment variables (no defaults):
 - _JUGGLE_TEST_DB (src/juggle_cli.py)
@@ -9,5 +8,6 @@ Required environment variables (no defaults):
 - JUGGLE_MAX_BACKGROUND_AGENTS (src/juggle_db.py)
 - JUGGLE_MAX_THREADS (src/juggle_db.py)
 
-Read .codesight/wiki/index.md for orientation (WHERE things live). Then read actual source files before implementing. Wiki articles are navigation aids, not implementation guides.
-Read .codesight/CODESIGHT.md for the complete AI context map including all routes, schema, components, libraries, config, middleware, and dependency graph.
+Read graphify-out/GRAPH_REPORT.md for orientation — god nodes and community structure show WHERE things live. Then read the actual source files in src/ before implementing. The graph is a navigation aid, not an implementation guide.
+
+See CLAUDE.md for the full design philosophy, versioning, and task-tracking conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,11 @@ Required environment variables (no defaults):
 After every major implementation:
 1. Bump `version` in `.claude-plugin/plugin.json` (patch = bug/minor, minor = feature)
 2. Commit with `feat:`/`fix:` prefix and version in body
-3. Mark done in `/Users/mikechen/Documents/personal/projects/juggle/TODO.md`
+3. Mark done in `TODO.md` (repo root)
 
 # Task Tracking
 
-Track in `/Users/mikechen/Documents/personal/projects/juggle/TODO.md`:
+Track in `TODO.md` (repo root):
 - New: `- [ ] <description>`
 - In-progress: prefix with `🔄 [IN PLANNING]` or `🔄 [IN PROGRESS]`
 - Done: `- [x] <description> ✅ YYYY-MM-DD` (move to Done section)

--- a/codex.md
+++ b/codex.md
@@ -1,7 +1,6 @@
 # Project Context
 
-This is a javascript project using raw-http.
-
+Python CLI project (Claude Code plugin). Source in `src/`.
 
 Required environment variables (no defaults):
 - _JUGGLE_TEST_DB (src/juggle_cli.py)
@@ -9,5 +8,6 @@ Required environment variables (no defaults):
 - JUGGLE_MAX_BACKGROUND_AGENTS (src/juggle_db.py)
 - JUGGLE_MAX_THREADS (src/juggle_db.py)
 
-Read .codesight/wiki/index.md for orientation (WHERE things live). Then read actual source files before implementing. Wiki articles are navigation aids, not implementation guides.
-Read .codesight/CODESIGHT.md for the complete AI context map including all routes, schema, components, libraries, config, middleware, and dependency graph.
+Read graphify-out/GRAPH_REPORT.md for orientation — god nodes and community structure show WHERE things live. Then read the actual source files in src/ before implementing. The graph is a navigation aid, not an implementation guide.
+
+See CLAUDE.md for the full design philosophy, versioning, and task-tracking conventions.

--- a/commands/search.md
+++ b/commands/search.md
@@ -1,3 +1,8 @@
+---
+description: Search the web and research KB, filter with Haiku, and report ranked results
+allowed-tools: Bash, mcp__web-search__search-web
+---
+
 # /juggle:search — Search + Filter
 
 Search the web MCP and research KB, filter with Haiku, and report results.
@@ -14,7 +19,7 @@ Search the web MCP and research KB, filter with Haiku, and report results.
 
 ```bash
 source ~/.juggle/.env 2>/dev/null; true
-KB_JSON=$(python3 /Users/mikechen/github/juggle//src/juggle_cmd_search.py "<QUERY>" --no-web <EXTRA_FLAGS>)
+KB_JSON=$(python3 ${CLAUDE_PLUGIN_ROOT}/src/juggle_cmd_search.py "<QUERY>" --no-web <EXTRA_FLAGS>)
 echo "$KB_JSON"
 ```
 
@@ -32,7 +37,7 @@ Pass both result sets to the filter script:
 
 ```bash
 source ~/.juggle/.env 2>/dev/null; true
-FILTERED=$(python3 /Users/mikechen/github/juggle//src/juggle_cmd_search.py "<QUERY>" \
+FILTERED=$(python3 ${CLAUDE_PLUGIN_ROOT}/src/juggle_cmd_search.py "<QUERY>" \
   --no-kb --filter \
   --web-results '<WEB_RESULTS_JSON>')
 echo "$FILTERED"
@@ -42,7 +47,7 @@ But since KB results are already in `$KB_JSON`, inject them by calling with both
 
 ```bash
 source ~/.juggle/.env 2>/dev/null; true
-FILTERED=$(python3 /Users/mikechen/github/juggle//src/juggle_cmd_search.py "<QUERY>" \
+FILTERED=$(python3 ${CLAUDE_PLUGIN_ROOT}/src/juggle_cmd_search.py "<QUERY>" \
   --filter \
   --web-results '<WEB_RESULTS_JSON>' \
   <EXTRA_FLAGS>)

--- a/commands/toggle-autopilot.md
+++ b/commands/toggle-autopilot.md
@@ -5,6 +5,11 @@ description: Toggle autonomous development mode on/off. When ON, hand off a list
 
 # /juggle:toggle-autopilot
 
+The flag below (`~/.juggle/autopilot`) is read by the `UserPromptSubmit` hook
+(`src/juggle_hooks.py`), which re-injects the autopilot directive on every turn
+while it's set — so the mode persists instead of being forgotten after this
+command scrolls out of context.
+
 Flip the flag, then act on the new state:
 
 ```bash

--- a/src/juggle_hooks.py
+++ b/src/juggle_hooks.py
@@ -25,6 +25,11 @@ from juggle_settings import get_settings as _get_settings
 _DATA_DIR = Path(_get_settings()["paths"]["data_dir"]).expanduser()
 DB_PATH = _DATA_DIR / "juggle.db"
 
+# Flag file written by /juggle:toggle-autopilot. Its presence means autopilot
+# mode is ON. Read here so the directive is re-asserted on every prompt — a
+# prompt-only toggle would be forgotten on the next turn.
+AUTOPILOT_FLAG = Path.home() / ".juggle" / "autopilot"
+
 logging.basicConfig(
     filename=str(_DATA_DIR / "juggle.log"),
     level=logging.INFO,
@@ -56,6 +61,35 @@ def is_active() -> bool:
 
 def get_db() -> JuggleDB:
     return JuggleDB(str(DB_PATH))
+
+
+# Concise re-assertion of the /juggle:toggle-autopilot loop. The full loop lives
+# in commands/toggle-autopilot.md; this is injected every turn so the behavior
+# persists once the flag is set, instead of relying on the model remembering it.
+_AUTOPILOT_DIRECTIVE = (
+    "--- AUTOPILOT MODE: ON ---\n"
+    "Autopilot is engaged (~/.juggle/autopilot present). Drive every requested "
+    "feature to completion autonomously — do NOT pause for approval:\n"
+    "1. Per feature: brainstorm/spec → devil's-advocate critique → resolve open "
+    "questions yourself at staff level (decide, note why, proceed).\n"
+    "2. Implement on a feature branch via dispatched agents (TDD); verify each "
+    "feature with a harness before starting the next.\n"
+    "3. Self-unblock: on a blocker or stalled agent, diagnose → recover → continue.\n"
+    "4. Escalate ONLY for: missing credentials, an irreversible/destructive "
+    "external action, or a product-direction fork with no defensible default.\n"
+    "Toggle off with /juggle:toggle-autopilot. See commands/toggle-autopilot.md "
+    "for the full loop."
+)
+
+
+def _autopilot_context() -> str:
+    """Return the autopilot directive if the flag file is set, else ''."""
+    try:
+        if AUTOPILOT_FLAG.exists():
+            return _AUTOPILOT_DIRECTIVE
+    except Exception as exc:
+        logging.warning("autopilot flag check failed: %s", exc)
+    return ""
 
 
 def _get_session_id(db) -> str:
@@ -209,19 +243,34 @@ def auto_approve_blocked_agents() -> None:
 
 
 def handle_user_prompt_submit(data: dict) -> None:
-    """Inject juggle context and record the user prompt."""
+    """Inject juggle context (plus autopilot directive) and record the user prompt."""
+    autopilot = _autopilot_context()
+
+    # Autopilot is independent of juggle mode — re-assert it even when inactive.
     if not is_active():
+        if autopilot:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "additionalContext": autopilot,
+                        }
+                    }
+                )
+            )
         sys.exit(0)
 
     auto_approve_blocked_agents()
 
     try:
         context = build_context_string()
-        if context:
+        combined = "\n\n".join(part for part in (autopilot, context) if part)
+        if combined:
             output = {
                 "hookSpecificOutput": {
                     "hookEventName": "UserPromptSubmit",
-                    "additionalContext": context,
+                    "additionalContext": combined,
                 }
             }
             print(json.dumps(output))

--- a/tests/test_juggle_hooks.py
+++ b/tests/test_juggle_hooks.py
@@ -297,3 +297,66 @@ def test_post_tool_use_no_agent_task_id_tracking(active_db, monkeypatch):
 
     thread = active_db.get_thread(thread_id)
     assert thread["status"] != "background"
+
+
+# ---------------------------------------------------------------------------
+# Autopilot enforcement tests (/juggle:toggle-autopilot flag is hook-read)
+# ---------------------------------------------------------------------------
+
+
+def test_autopilot_context_empty_when_flag_absent(active_db, monkeypatch, tmp_path):
+    juggle_hooks = _reload_hooks(monkeypatch, active_db)
+    monkeypatch.setattr(juggle_hooks, "AUTOPILOT_FLAG", tmp_path / "autopilot")
+    assert juggle_hooks._autopilot_context() == ""
+
+
+def test_autopilot_context_present_when_flag_set(active_db, monkeypatch, tmp_path):
+    juggle_hooks = _reload_hooks(monkeypatch, active_db)
+    flag = tmp_path / "autopilot"
+    flag.touch()
+    monkeypatch.setattr(juggle_hooks, "AUTOPILOT_FLAG", flag)
+    assert "AUTOPILOT MODE: ON" in juggle_hooks._autopilot_context()
+
+
+def test_user_prompt_submit_injects_autopilot_when_active(
+    active_db, monkeypatch, tmp_path, capsys
+):
+    juggle_hooks = _reload_hooks(monkeypatch, active_db)
+    flag = tmp_path / "autopilot"
+    flag.touch()
+    monkeypatch.setattr(juggle_hooks, "AUTOPILOT_FLAG", flag)
+
+    with pytest.raises(SystemExit):
+        juggle_hooks.handle_user_prompt_submit({"prompt": ""})
+
+    out = json.loads(capsys.readouterr().out)
+    assert "AUTOPILOT MODE: ON" in out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_user_prompt_submit_injects_autopilot_when_inactive(
+    active_db, monkeypatch, tmp_path, capsys
+):
+    active_db.set_active(False)
+    juggle_hooks = _reload_hooks(monkeypatch, active_db)
+    flag = tmp_path / "autopilot"
+    flag.touch()
+    monkeypatch.setattr(juggle_hooks, "AUTOPILOT_FLAG", flag)
+
+    with pytest.raises(SystemExit):
+        juggle_hooks.handle_user_prompt_submit({"prompt": ""})
+
+    out = json.loads(capsys.readouterr().out)
+    assert "AUTOPILOT MODE: ON" in out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_user_prompt_submit_no_autopilot_when_inactive_and_flag_absent(
+    active_db, monkeypatch, tmp_path, capsys
+):
+    active_db.set_active(False)
+    juggle_hooks = _reload_hooks(monkeypatch, active_db)
+    monkeypatch.setattr(juggle_hooks, "AUTOPILOT_FLAG", tmp_path / "autopilot")
+
+    with pytest.raises(SystemExit):
+        juggle_hooks.handle_user_prompt_submit({"prompt": ""})
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Fixes 4 issues surfaced by a review of the prompt-side surface (slash commands, skills, instruction files), including wiring up code enforcement for an otherwise prompt-only feature.

### #2 — Autopilot is now hook-enforced (was prompt-only)
`/juggle:toggle-autopilot` wrote `~/.juggle/autopilot` but **nothing read it**, so the autopilot loop only governed behavior on the single turn the user toggled it — forgotten on the next turn. This violated the project's #1 design rule ("Logic and behavioral rules go in code or hooks — never prompt-only").

- `UserPromptSubmit` hook now reads the flag and re-injects a concise autopilot directive **every turn** while it's set.
- Works even when juggle mode is inactive (the command doesn't require juggle mode).
- Adds `AUTOPILOT_FLAG` + `_autopilot_context()` and 4 tests.

### #1 — Corrected stale, wrong agent instruction files
`AGENTS.md`, `.cursorrules`, and `codex.md` were byte-identical and **factually wrong**: they declared *"This is a javascript project using raw-http"* and pointed at a nonexistent `.codesight/` directory. Rewritten to match reality — Python CLI plugin, `graphify-out/` knowledge graph.

### #3 — Fixed dead path in CLAUDE.md
*Versioning* and *Task Tracking* referenced a machine-specific `/Users/mikechen/.../TODO.md` absent from the repo. Repointed to repo-root `TODO.md`.

### #4 — Cleaned up commands/search.md
Added missing frontmatter (`description` + `allowed-tools`) — it was the only real command without any — and replaced a hardcoded `/Users/mikechen/github/juggle//src/...` path with `${CLAUDE_PLUGIN_ROOT}`.

Bumps plugin version `1.35.1` → `1.36.0`.

## Testing
- `uv run pytest tests/test_juggle_hooks.py` — 4 new autopilot tests pass, 40 others pass.
- 4 pre-existing failures (Stop/PreToolUse/PostToolUse handlers) were verified to fail identically on the base commit — unrelated to this change.

## Notes
- `graphify update` was skipped (graphify not installed in the CI environment); regenerate locally.
- Not included here: the earlier CLI-side findings (dead `set-agent`, duplicated `record/clear-pending-decision`, self-heal DB-bootstrap drift) — happy to do those in a follow-up.

https://claude.ai/code/session_01Q8LaGgHEegH7E2KGm3c7ci

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8LaGgHEegH7E2KGm3c7ci)_