### PR TITLE
refactor(commands): fix machine-specific paths; centralize vault resolution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "juggle",
   "description": "Multi-topic conversation orchestrator. Manage parallel conversation threads within a single Claude Code session \u2014 discuss one topic while background agents research or build for others.",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "author": {
     "name": "Mike Chen"
   },

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -24,29 +24,8 @@ allowed-tools: Read, Edit, Write, Bash, mcp__personal-mcp__extract_text_from_fil
 At the start of each mode, resolve VAULT_PATH, VAULT_NAME, and INBOX via:
 
 ```bash
-VAULT_PATH=$(python3 -c "
-import sys, os
-sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/src')
-from juggle_settings import get_settings
-s = get_settings()
-vault_rel = s['paths'].get('vault', '/Documents/personal')
-print(os.path.expanduser('~') + vault_rel)
-" 2>/dev/null)
-
-VAULT_NAME=$(python3 -c "
-import sys, os
-from pathlib import Path
-sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/src')
-from juggle_settings import get_settings
-s = get_settings()
-explicit = s['paths'].get('vault_name', '')
-if explicit:
-    print(explicit)
-else:
-    vault_rel = s['paths'].get('vault', '/Documents/personal')
-    print(Path(vault_rel.rstrip('/')).name)
-" 2>/dev/null)
-
+VAULT_PATH=$(uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py vault-path)
+VAULT_NAME=$(uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py vault-name)
 INBOX="${VAULT_PATH}/inbox.md"
 ```
 

--- a/commands/deep-research.md
+++ b/commands/deep-research.md
@@ -164,13 +164,7 @@ REPORT=$(uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cmd_research.py "<TOPIC>" <NO_W
 rm -f "$WEB_FILE"
 
 ### Step 5 — Save report to vault
-VAULT_PATH=$(uv run python -c "
-import sys, os
-sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/src')
-from juggle_settings import get_settings
-vault_rel = get_settings()['paths'].get('vault', '')
-print(os.path.expanduser('~') + vault_rel if vault_rel else '')
-" 2>/dev/null)
+VAULT_PATH=$(uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py vault-path)
 REPORT_FILE="${VAULT_PATH}/research/$(date +%Y-%m-%d)-<SLUG>.md"
 {
   printf "# Research: <TOPIC>\nDate: $(date +%Y-%m-%d)\n\n"

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -152,17 +152,18 @@ changes must follow the cycle.
 ## Always finalize — never wait at the prompt
 
 Your task ENDS with a `complete-agent` or `fail-agent` Bash call. You must
-NOT emit a final recap and wait at the input prompt. Examples of correct
-final actions:
+NOT emit a final recap and wait at the input prompt. Use the juggle_cli
+path from your AGENT ROLE block's COMPLETION line (written `<juggle-cli>`
+below) — do not hardcode an absolute path. Examples of correct final actions:
 
 - Work done cleanly:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "Done. <summary>" --retain "<notes>" --role <role>
+  <juggle-cli> complete-agent <THREAD> "Done. <summary>" --retain "<notes>" --role <role>
 
 - Hit a wall:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "⚠️ BLOCKER: <description>" --retain "<context>" --role <role>
+  <juggle-cli> complete-agent <THREAD> "⚠️ BLOCKER: <description>" --retain "<context>" --role <role>
 
 - Have unresolved questions:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "Done with caveats. See open questions." --open-questions '[{"q": "...", "context": "..."}]' --role <role>
+  <juggle-cli> complete-agent <THREAD> "Done with caveats. See open questions." --open-questions '[{"q": "...", "context": "..."}]' --role <role>
 
 Do NOT ask the user "want me to commit?" or "shall I proceed?" — decide
 autonomously from the task spec. The orchestrator already approved scope
@@ -201,17 +202,18 @@ VERSION BUMP: patch=fix, minor=feature, major=breaking. State target version in 
 ## Always finalize — never wait at the prompt
 
 Your task ENDS with a `complete-agent` or `fail-agent` Bash call. You must
-NOT emit a final recap and wait at the input prompt. Examples of correct
-final actions:
+NOT emit a final recap and wait at the input prompt. Use the juggle_cli
+path from your AGENT ROLE block's COMPLETION line (written `<juggle-cli>`
+below) — do not hardcode an absolute path. Examples of correct final actions:
 
 - Work done cleanly:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "Done. <summary>" --retain "<notes>" --role <role>
+  <juggle-cli> complete-agent <THREAD> "Done. <summary>" --retain "<notes>" --role <role>
 
 - Hit a wall:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "⚠️ BLOCKER: <description>" --retain "<context>" --role <role>
+  <juggle-cli> complete-agent <THREAD> "⚠️ BLOCKER: <description>" --retain "<context>" --role <role>
 
 - Have unresolved questions:
-  uv run /Users/mikechen/github/juggle/src/juggle_cli.py complete-agent <THREAD> "Done with caveats. See open questions." --open-questions '[{"q": "...", "context": "..."}]' --role <role>
+  <juggle-cli> complete-agent <THREAD> "Done with caveats. See open questions." --open-questions '[{"q": "...", "context": "..."}]' --role <role>
 
 Do NOT ask the user "want me to commit?" or "shall I proceed?" — decide
 autonomously from the task spec. The orchestrator already approved scope

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -15,13 +15,13 @@ Runs the `juggle doctor` CLI which:
 ## Run
 
 ```bash
-uv run ~/github/juggle/src/juggle_cli.py doctor
+uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py doctor
 ```
 
 For a preview without writes:
 
 ```bash
-uv run ~/github/juggle/src/juggle_cli.py doctor --dry-run
+uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py doctor --dry-run
 ```
 
 Report the output. If the user wants to revert, restore `~/.juggle/config.json.bak-pre-1.21` and downgrade Juggle to a 1.20.x release.

--- a/commands/start.md
+++ b/commands/start.md
@@ -94,9 +94,9 @@ Coordinates only. Edit/Write/NotebookEdit blocked by hook.
 
 **Proactive failure investigation:** When any error/issue/potential failure surfaces in orchestration (watchdog alerts, failed/blocked/stalled agents, orphaned threads, false-positive action items, broken invariants), investigate proactively and autonomously — no permission needed to investigate or diagnose. Determine root cause + the precise fix. The ONLY gate is right before APPLYING the fix: present root cause + proposed change, then prompt the user to proceed. Never silently apply a fix; never ask permission merely to investigate.
 
-**DA action items:** 🔴 input needed → `request-action --tier 2`; 🟡 auto-resolved → note inline.
+**DA action items:** 🔴 input needed → `request-action --type decision`; 🟡 auto-resolved → note inline.
 ```bash
-uv run juggle_cli.py request-action <thread_id> "DA finding: <decision>" --tier 2
+uv run ${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py request-action <thread_id> "DA finding: <decision>" --type decision
 ```
 
 **Code review:** always background, never inline.

--- a/src/juggle_cli.py
+++ b/src/juggle_cli.py
@@ -59,6 +59,16 @@ def _get_vault_name() -> str:
     return _get_vault_root().name
 
 
+def cmd_vault_path(args):
+    """Print the absolute vault root path (single source of truth for commands)."""
+    print(str(_get_vault_root()))
+
+
+def cmd_vault_name(args):
+    """Print the vault name (used for obsidian:// URIs)."""
+    print(_get_vault_name())
+
+
 VAULT_ROOT = _get_vault_root()
 
 # Re-export commonly used symbols for backward compatibility with tests
@@ -598,6 +608,12 @@ def main():
     p_open = subparsers.add_parser("open-in-editor", help="Open file in nvim server")
     p_open.add_argument("file", help="Path to file to open")
     p_open.set_defaults(func=cmd_open_in_editor)
+
+    # vault-path / vault-name (single source of truth for commands resolving the vault)
+    p_vault_path = subparsers.add_parser("vault-path", help="Print absolute vault root path")
+    p_vault_path.set_defaults(func=cmd_vault_path)
+    p_vault_name = subparsers.add_parser("vault-name", help="Print vault name (for obsidian:// URIs)")
+    p_vault_name.set_defaults(func=cmd_vault_name)
 
     # research
     p_research = subparsers.add_parser("research", help="Search research KB")

--- a/tests/test_vault_commands.py
+++ b/tests/test_vault_commands.py
@@ -1,0 +1,54 @@
+"""Tests for the vault-path / vault-name CLI commands.
+
+These wrap _get_vault_root() / _get_vault_name() so slash commands can resolve
+the vault via a single source of truth instead of duplicated inline python.
+"""
+
+import sys
+from pathlib import Path
+
+SRC_DIR = str(Path(__file__).parent.parent / "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import juggle_cli
+
+
+def test_cmd_vault_path_prints_root(capsys, monkeypatch):
+    monkeypatch.setattr(juggle_cli, "_get_vault_root", lambda: Path("/home/u/Vault"))
+    juggle_cli.cmd_vault_path(None)
+    assert capsys.readouterr().out.strip() == "/home/u/Vault"
+
+
+def test_cmd_vault_name_prints_name(capsys, monkeypatch):
+    monkeypatch.setattr(juggle_cli, "_get_vault_name", lambda: "MyVault")
+    juggle_cli.cmd_vault_name(None)
+    assert capsys.readouterr().out.strip() == "MyVault"
+
+
+def test_vault_root_handles_tilde_prefix(monkeypatch):
+    # The old inline `expanduser('~') + vault_rel` mishandled this; the real
+    # function must expand a ~-prefixed config correctly.
+    monkeypatch.setattr(juggle_cli, "get_settings", lambda: {"paths": {"vault": "~/Notes"}})
+    assert juggle_cli._get_vault_root() == Path.home() / "Notes"
+
+
+def test_vault_root_handles_leading_slash(monkeypatch):
+    monkeypatch.setattr(
+        juggle_cli, "get_settings", lambda: {"paths": {"vault": "/Documents/personal"}}
+    )
+    assert juggle_cli._get_vault_root() == Path.home() / "Documents/personal"
+
+
+def test_vault_name_prefers_explicit_then_falls_back(monkeypatch):
+    monkeypatch.setattr(
+        juggle_cli,
+        "get_settings",
+        lambda: {"paths": {"vault": "/Documents/personal", "vault_name": "Brain"}},
+    )
+    assert juggle_cli._get_vault_name() == "Brain"
+
+    monkeypatch.setattr(
+        juggle_cli, "get_settings", lambda: {"paths": {"vault": "/Documents/personal"}}
+    )
+    assert juggle_cli._get_vault_name() == "personal"


### PR DESCRIPTION
## Summary

A cleanup/efficiency pass over the slash commands and skills (follow-up to #28/#29).

### Machine-specific & broken CLI paths
- **`doctor.md`** — used `~/github/juggle/src/juggle_cli.py` → now `${CLAUDE_PLUGIN_ROOT}/src/juggle_cli.py`.
- **`start.md`** — used a bare relative `juggle_cli.py` → now `${CLAUDE_PLUGIN_ROOT}/...`.
- **`delegate.md`** — hardcoded `/Users/mikechen/github/juggle/src/juggle_cli.py` (×6) in the **agent behavioral spec**. Agent panes launch with `env -u CLAUDE_PLUGIN_DATA JUGGLE_IS_AGENT=1 JUGGLE_AGENT_ROLE=…` and **do not** export `CLAUDE_PLUGIN_ROOT`, so a blind `${CLAUDE_PLUGIN_ROOT}` swap would break there. The correct, machine-independent path is already injected into every agent via the role-anchor `COMPLETION` line (`juggle_context.py:140`), so the examples now reference that (`<juggle-cli>`) instead of hardcoding.

### Centralized vault resolution (DRY + latent bug fix)
Three commands resolved the vault with fragile inline `python -c` blocks (`capture.md` ×2, `deep-research.md` ×1) that reimplemented `_get_vault_root()`/`_get_vault_name()` — and the inline copies had a **latent bug**: `expanduser('~') + vault_rel` mishandles a `~`-prefixed vault config (e.g. `~/Notes` → `/home/user~/Notes`), which the real functions handle.

- Added **`vault-path`** / **`vault-name`** CLI commands wrapping the existing functions.
- Replaced the 3 inline blocks with a single CLI call each → one source of truth, bug gone, ~30 lines of shell-python removed.

### Bug: nonexistent flag
`start.md` told the orchestrator to run `request-action --tier 2`, but that command has no `--tier` flag (only `--type {question,manual_step,decision,failure}` / `--priority {low,normal,high}`) — it would error. Changed to `--type decision`.

Adds `tests/test_vault_commands.py`. Bumps plugin version `1.36.1` → `1.36.2`.

## Testing
- `uv run pytest tests/test_vault_commands.py` — 5 pass (incl. regression tests for the `~`-prefix and leading-slash cases).
- `uv run pytest tests/test_juggle_cli.py` — 59 pass (no regressions from the new commands).
- Smoke: `uv run src/juggle_cli.py vault-path` → prints the resolved root.

## Note
- `vault-path`/`vault-name` go through `main()`, which runs the stale-agent reaper like every other CLI call — a small one-time overhead per invocation, consistent with existing command usage; not in any hot loop.
- Out of scope (flagged, not changed): two unrelated one-off `research_kb` settings reads via inline `python -c` (`deep-research.md:121`, `init.md`), and the schedule skills' `cd ~/github/juggle` (cron self-dogfood context).

https://claude.ai/code/session_01Q8LaGgHEegH7E2KGm3c7ci

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8LaGgHEegH7E2KGm3c7ci)_