### PR TITLE
fix: stop agent sessions from inheriting orchestrator context (token saving)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "juggle",
   "description": "Multi-topic conversation orchestrator. Manage parallel conversation threads within a single Claude Code session \u2014 discuss one topic while background agents research or build for others.",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "author": {
     "name": "Mike Chen"
   },

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# TODO
+
+## In Progress
+
+(none)
+
+## Done
+
+- [x] Stop agent sessions from inheriting orchestrator context (token saving): guard `UserPromptSubmit`, `SessionStart`, and `PostToolUse` hooks + `juggle_context._build` on `JUGGLE_IS_AGENT`. Agents now get only their role anchor instead of the full "JUGGLE ACTIVE" dashboard (~2000 tokens/turn), the `/juggle:start` startup tree at boot, and per-read "ORCHESTRATOR VIOLATION" warnings. ✅ 2026-05-31

--- a/src/juggle_context.py
+++ b/src/juggle_context.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Juggle Context - builds additionalContext for UserPromptSubmit hook."""
 
+import os
 import re
 
 from juggle_cli_common import _humanize_dt, _extract_decision_prompt
@@ -142,6 +143,15 @@ def _render_agent_role_anchor() -> str:
 
 
 def _build(db: JuggleDB) -> str:
+    # Agent sessions get ONLY their role anchor — never the orchestrator
+    # dashboard. The "JUGGLE ACTIVE" block is orchestrator-only context
+    # (explicitly tagged "do not forward to sub-agents") and an agent is told
+    # to ignore all of it, so injecting it wastes up to context_injection_char_limit
+    # (~2000 tokens) per task prompt on every dispatched agent. Returned before
+    # any DB query so it costs nothing and needs no active orchestrator.
+    if os.environ.get("JUGGLE_IS_AGENT") == "1":
+        return _render_agent_role_anchor()
+
     if not db.is_active():
         return ""
 

--- a/src/juggle_hooks.py
+++ b/src/juggle_hooks.py
@@ -244,6 +244,31 @@ def auto_approve_blocked_agents() -> None:
 
 def handle_user_prompt_submit(data: dict) -> None:
     """Inject juggle context (plus autopilot directive) and record the user prompt."""
+    # Agent sessions: inject ONLY the role anchor (build_context_string returns
+    # anchor-only when JUGGLE_IS_AGENT=1). Skip the orchestrator dashboard, the
+    # autopilot directive, the agent-pane auto-approve sweep, the thread message
+    # write, and Hindsight retention — an agent's prompt is a task, not a user
+    # turn, so writing it into orchestrator history (and re-injecting ~2000 tokens
+    # of dashboard every turn) is pure waste.
+    if os.environ.get("JUGGLE_IS_AGENT") == "1":
+        try:
+            anchor = build_context_string()
+            if anchor:
+                print(
+                    json.dumps(
+                        {
+                            "hookSpecificOutput": {
+                                "hookEventName": "UserPromptSubmit",
+                                "additionalContext": anchor,
+                            }
+                        }
+                    )
+                )
+        except Exception as exc:
+            _record_error_safe(exc, "juggle_hooks.UserPromptSubmit")
+            logging.error("UserPromptSubmit agent-anchor error: %s", exc, exc_info=True)
+        sys.exit(0)
+
     autopilot = _autopilot_context()
 
     # Autopilot is independent of juggle mode — re-assert it even when inactive.
@@ -366,6 +391,12 @@ def handle_stop(data: dict) -> None:
 
 def handle_session_start(data: dict) -> None:
     """Inject restoration context on resume or compact."""
+    # Agent sessions never need the orchestrator's startup dashboard (topics tree
+    # + Hindsight recalls). Without this guard every dispatched agent effectively
+    # "calls /juggle:start" at boot, paying for context it is told to ignore.
+    if os.environ.get("JUGGLE_IS_AGENT") == "1":
+        sys.exit(0)
+
     if not is_active():
         db = get_db()
         if db.get_threads_by_status("open"):
@@ -536,6 +567,14 @@ def handle_pre_tool_use(data: dict) -> None:
 
 def handle_post_tool_use(data: dict) -> None:
     """Detect orchestrator violations and JUGGLE ACTIVE leaks in tool calls."""
+    # Agent sessions: none of the orchestrator-violation logic applies. Agents
+    # are SUPPOSED to Read/Grep/Glob and they never call Agent. Without this
+    # guard every file read in an agent injects a ~40-word "ORCHESTRATOR
+    # VIOLATION" warning into the agent's context — a per-tool-call token leak
+    # and a false accusation. Exit before any check.
+    if os.environ.get("JUGGLE_IS_AGENT") == "1":
+        sys.exit(0)
+
     if not is_active():
         sys.exit(0)
 

--- a/tests/test_juggle_context.py
+++ b/tests/test_juggle_context.py
@@ -6,7 +6,57 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from juggle_db import JuggleDB
-from juggle_context import ContextBuilder
+from juggle_context import ContextBuilder, build_context_string
+
+
+# ---------------------------------------------------------------------------
+# Agent sessions must get ONLY the role anchor — never the orchestrator
+# dashboard (token-saving: the "JUGGLE ACTIVE" block is orchestrator-only and
+# explicitly tagged "do not forward to sub-agents").
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def busy_active_db(tmp_path):
+    """An active DB with content that WOULD render a fat dashboard."""
+    db = JuggleDB(str(tmp_path / "test.db"))
+    db.init_db()
+    db.set_active(True)
+    tid = db.create_thread("Topic A", session_id="s1")
+    db.set_current_thread(tid)
+    db.add_message(tid, "user", "a real question about the auth flow")
+    db.add_message(tid, "assistant", "a real answer about the auth flow")
+    db.add_action_item(thread_id=tid, message="do the thing", type_="task")
+    return db
+
+
+def test_agent_session_gets_only_role_anchor(busy_active_db, monkeypatch):
+    monkeypatch.setenv("JUGGLE_IS_AGENT", "1")
+    monkeypatch.setenv("JUGGLE_AGENT_ROLE", "coder")
+    ctx = ContextBuilder(busy_active_db).build()
+    # Anchor present...
+    assert "--- AGENT ROLE ---" in ctx
+    assert "ROLE: coder" in ctx
+    # ...and NONE of the orchestrator dashboard.
+    assert "JUGGLE ACTIVE" not in ctx
+    assert "Q&A history" not in ctx
+    assert "real question" not in ctx
+
+
+def test_agent_session_anchorless_role_returns_empty(busy_active_db, monkeypatch):
+    # JUGGLE_IS_AGENT but no recognised role → no anchor, and still no dashboard.
+    monkeypatch.setenv("JUGGLE_IS_AGENT", "1")
+    monkeypatch.delenv("JUGGLE_AGENT_ROLE", raising=False)
+    ctx = ContextBuilder(busy_active_db).build()
+    assert "JUGGLE ACTIVE" not in ctx
+    assert ctx == ""
+
+
+def test_orchestrator_session_still_gets_dashboard(busy_active_db, monkeypatch):
+    monkeypatch.delenv("JUGGLE_IS_AGENT", raising=False)
+    ctx = build_context_string(db_path=str(busy_active_db.db_path))
+    assert "JUGGLE ACTIVE" in ctx
+    assert "Q&A history" in ctx
 
 
 @pytest.fixture

--- a/tests/test_juggle_hooks.py
+++ b/tests/test_juggle_hooks.py
@@ -191,6 +191,54 @@ def test_pre_tool_use_allows_non_blocked_tool(
 
 
 # ---------------------------------------------------------------------------
+# Agent-session context-injection guards (token saving)
+# ---------------------------------------------------------------------------
+
+
+def test_session_start_agent_injects_nothing(monkeypatch, capsys):
+    monkeypatch.setenv("JUGGLE_IS_AGENT", "1")
+    import juggle_hooks
+
+    with pytest.raises(SystemExit) as exc_info:
+        juggle_hooks.handle_session_start({"reason": "startup"})
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_user_prompt_submit_agent_anchor_only_no_dashboard(monkeypatch, capsys):
+    monkeypatch.setenv("JUGGLE_IS_AGENT", "1")
+    monkeypatch.setenv("JUGGLE_AGENT_ROLE", "coder")
+    import juggle_hooks
+
+    with pytest.raises(SystemExit) as exc_info:
+        juggle_hooks.handle_user_prompt_submit(
+            {"prompt": "[JUGGLE_THREAD:x] implement the widget"}
+        )
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert "AGENT ROLE" in ctx
+    assert "ROLE: coder" in ctx
+    # Orchestrator dashboard must NOT be present in an agent session.
+    assert "JUGGLE ACTIVE" not in ctx
+
+
+def test_post_tool_use_agent_no_violation_warning(monkeypatch, capsys):
+    monkeypatch.setenv("JUGGLE_IS_AGENT", "1")
+    import juggle_hooks
+
+    with pytest.raises(SystemExit) as exc_info:
+        juggle_hooks.handle_post_tool_use({"tool_name": "Read"})
+
+    assert exc_info.value.code == 0
+    # No "ORCHESTRATOR VIOLATION" warning injected for an agent's own reads.
+    assert capsys.readouterr().out.strip() == ""
+
+
+# ---------------------------------------------------------------------------
 # Classification candidate filter tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Background agents launch as full `claude` processes in tmux panes. They share the juggle DB — `paths.data_dir` resolves to `~/.claude/juggle` independently of `CLAUDE_PLUGIN_DATA` (which is unset for agents), so `is_active()` returns **True** inside every agent. That meant the plugin's context hooks ran their *full* body in agent sessions, injecting orchestrator-only context the agent is explicitly told to ignore. The `--- JUGGLE ACTIVE ---` block even carries the header *"(do not forward to sub-agents)"* — yet the hooks injected it straight into the sub-agent.

(Proof the hooks fire in agents: `handle_pre_tool_use` already checks `JUGGLE_IS_AGENT` to bypass the write-blocker — pointless if hooks didn't run there.)

## Three leaks fixed (guard on `JUGGLE_IS_AGENT`)

| Hook | Before (per agent) | After |
|---|---|---|
| `UserPromptSubmit` | full dashboard ≤8000 chars (~2000 tokens) **per task prompt** + autopilot directive + wrote the agent task into orchestrator thread history + Hindsight retention | injects **only the role anchor** |
| `SessionStart` | `build_startup_output` (topics tree + Hindsight recalls) at boot — agents effectively "called `/juggle:start`" | no-op |
| `PostToolUse` | ~40-word *"⚠️ ORCHESTRATOR VIOLATION: you used [Read]…"* injected on **every** agent `Read`/`Grep`/`Glob`/`WebFetch`/`WebSearch` (per-tool-call leak **and** a false accusation — agents are supposed to read) | no-op |

`juggle_context._build` now returns the role anchor only when `JUGGLE_IS_AGENT=1`, *before* any DB query, so the anchor (role identity + `complete-agent` line) still reaches the agent while the dashboard never does.

## Tests

6 new tests, all green:
- `test_juggle_context.py`: agent session → anchor-only; anchorless role → empty; orchestrator session → still gets the full dashboard (no regression).
- `test_juggle_hooks.py`: `SessionStart`/`PostToolUse` inject nothing for agents; `UserPromptSubmit` injects anchor-only (no `JUGGLE ACTIVE`).

Related context/hook suites (`test_juggle_context`, `test_context_injection_v2`, `test_cmd_context`, `test_agent_prompt_conventions`, `test_juggle_tmux`) pass. Note: 4 `test_juggle_hooks` failures are **pre-existing** in a fresh clone (the suite is coupled to the author's home path, e.g. `/Users/mikechen/...`) and are unaffected by this change — verified via `git stash`.

## Follow-ups (not in this PR — investigation findings)

- **Stop hook** has no agent guard: an agent's final assistant message is written into the orchestrator's current thread, indirectly *inflating* future dashboard injections. Left out to avoid removing the Class-B self-heal transcript scan without a call from the maintainer.
- **MCP tool-definition bloat** is likely the largest remaining lever: each agent loads every configured MCP server's tool defs (often dozens) it never uses. The `agent.disallowed_tools_universal` / per-role denylists already exist for exactly this — extending them is deployment-specific.

Version: 1.36.4

https://claude.ai/code/session_01LwtGrWdtbKBChtqY8XR8mw

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwtGrWdtbKBChtqY8XR8mw)_