### PR TITLE
fix(docs): remove stale _JUGGLE_TEST_DB export from CLAUDE.md test setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Python CLI project (Claude Code plugin). Source in `src/`.
 Code map, domain layout, pinned entry points, and LOC-gate policy: `docs/ARCHITECTURE.md`.
 
 Required environment variables (no defaults):
-- _JUGGLE_TEST_DB, CLAUDE_PLUGIN_DATA (juggle_cli.py)
+- CLAUDE_PLUGIN_DATA (juggle_cli.py)
 - JUGGLE_MAX_BACKGROUND_AGENTS, JUGGLE_MAX_THREADS (juggle_db.py)
 
 # Testing
@@ -19,7 +19,6 @@ the hooks (e.g. `test_juggle_hooks.py`) run against the **shared** DB at
 Set up the shared DB once per fresh checkout/container before running the suite:
 
 ```bash
-export _JUGGLE_TEST_DB="$HOME/.claude/juggle/juggle.db"   # point CLI at the shared DB
 export CLAUDE_PLUGIN_DATA="$HOME/.claude/juggle"
 export JUGGLE_MAX_BACKGROUND_AGENTS=5 JUGGLE_MAX_THREADS=10
 uv run python src/juggle_cli.py init-db   # create all tables (fresh DB)

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -1590,5 +1590,19 @@
   "1588": "Community 1588",
   "1589": "Community 1589",
   "1590": "Community 1590",
-  "1591": "Community 1591"
+  "1591": "Community 1591",
+  "1592": "Community 1592",
+  "1593": "Community 1593",
+  "1594": "Community 1594",
+  "1595": "Community 1595",
+  "1596": "Community 1596",
+  "1597": "Community 1597",
+  "1598": "Community 1598",
+  "1599": "Community 1599",
+  "1600": "Community 1600",
+  "1601": "Community 1601",
+  "1602": "Community 1602",
+  "1603": "Community 1603",
+  "1604": "Community 1604",
+  "1605": "Community 1605"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - juggle  (2026-06-17)
+# Graph Report - juggle-juggle-BX  (2026-06-17)
 
 ## Corpus Check
-- 441 files · ~458,801 words
+- 437 files · ~453,688 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10820 nodes · 17891 edges · 1592 communities (448 shown, 1144 thin omitted)
+- 10825 nodes · 17899 edges · 1606 communities (459 shown, 1147 thin omitted)
 - Extraction: 73% EXTRACTED · 27% INFERRED · 0% AMBIGUOUS · INFERRED: 4890 edges (avg confidence: 0.63)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0314f5ff`
+- Built from commit: `7e15097b`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -1598,6 +1598,20 @@
 - [[_COMMUNITY_Community 1589|Community 1589]]
 - [[_COMMUNITY_Community 1590|Community 1590]]
 - [[_COMMUNITY_Community 1591|Community 1591]]
+- [[_COMMUNITY_Community 1592|Community 1592]]
+- [[_COMMUNITY_Community 1593|Community 1593]]
+- [[_COMMUNITY_Community 1594|Community 1594]]
+- [[_COMMUNITY_Community 1595|Community 1595]]
+- [[_COMMUNITY_Community 1596|Community 1596]]
+- [[_COMMUNITY_Community 1597|Community 1597]]
+- [[_COMMUNITY_Community 1598|Community 1598]]
+- [[_COMMUNITY_Community 1599|Community 1599]]
+- [[_COMMUNITY_Community 1600|Community 1600]]
+- [[_COMMUNITY_Community 1601|Community 1601]]
+- [[_COMMUNITY_Community 1602|Community 1602]]
+- [[_COMMUNITY_Community 1603|Community 1603]]
+- [[_COMMUNITY_Community 1604|Community 1604]]
+- [[_COMMUNITY_Community 1605|Community 1605]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `JuggleDB` - 995 edges
@@ -1612,15 +1626,15 @@
 10. `HSplitter` - 121 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `test_check_task_guard_allows_operator_states_and_unbound()` --calls--> `check_task_guard()`  [INFERRED]
-  tests/test_graph_contract.py → src/juggle_cmd_agents_graph.py
-- `test_check_task_guard_refuses_tick_owned_states()` --calls--> `check_task_guard()`  [INFERRED]
-  tests/test_graph_contract.py → src/juggle_cmd_agents_graph.py
 - `CockpitApp` --uses--> `Convert a thread label like 'A' or 'AB' to a list of Textual key names.     Acti`  [INFERRED]
   src/juggle_cockpit.py → tests/test_cockpit_keys.py
 - `CockpitApp` --uses--> `Convert a thread label like 'A' or 'AB' to a list of Textual key names.     Acti`  [INFERRED]
   src/juggle_cockpit.py → tests/test_cockpit_keys.py
 - `CockpitApp` --uses--> `Pressing 's' with an unknown label shows a warning notification (no crash).`  [INFERRED]
+  src/juggle_cockpit.py → tests/test_cockpit_keys.py
+- `CockpitApp` --uses--> `Pressing 's' with an unknown label shows a warning notification (no crash).`  [INFERRED]
+  src/juggle_cockpit.py → tests/test_cockpit_keys.py
+- `CockpitApp` --uses--> `Pressing 's' with a valid label calls set_current_thread.`  [INFERRED]
   src/juggle_cockpit.py → tests/test_cockpit_keys.py
 
 ## Import Cycles
@@ -1628,15 +1642,15 @@
 - 1-file cycle: `src/harnesses/__init__.py -> src/harnesses/__init__.py`
 - 1-file cycle: `src/juggle_selfheal.py -> src/juggle_selfheal.py`
 
-## Communities (1592 total, 1144 thin omitted)
+## Communities (1606 total, 1147 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.02
-Nodes (221): Return the tail of text, capped at max_chars., Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return the tail of text, capped at max_chars., Return the tail of text, capped at max_chars., Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Generate a 5-10 word title. Fallback chain: OpenRouter → Haiku → first 5 words. (+213 more)
+Nodes (203): Return the tail of text, capped at max_chars., Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return the tail of text, capped at max_chars., Return the tail of text, capped at max_chars., Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Return a concise actionable prompt for a ⏸️ waiting thread.      Extracts the la, Generate a 5-10 word title. Fallback chain: OpenRouter → Haiku → first 5 words. (+195 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (167): CockpitState, Panel, ScheduledTask, GraphDag, Lazily-loaded DAG for the armed project (graph mode only). Read-only., Lazily-loaded DAG for one armed project (graph mode only). Read-only., Action, Agent (+159 more)
+Cohesion: 0.06
+Nodes (147): CockpitState, ScheduledTask, GraphDag, Lazily-loaded DAG for the armed project (graph mode only). Read-only., Lazily-loaded DAG for one armed project (graph mode only). Read-only., Action, Agent, CockpitState (+139 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.07
@@ -1660,15 +1674,15 @@ Nodes (7): Returns False when gh returns empty list, Returns True when exact tit
 
 ### Community 8 - "Community 8"
 Cohesion: 0.04
-Nodes (94): Cockpit screenshot rendering (PNG/JPG/SVG via Rich record + cairosvg).  Extracte, Render the cockpit to ``path`` (PNG/JPG/SVG). Returns the written path.      gra, save_screenshot(), _add_topic_row(), _pane_border(), pick_breakpoint(), Panel, Render topics panel.      Wide: one row per topic with glyph + [label] + title. (+86 more)
+Nodes (94): Panel, Cockpit screenshot rendering (PNG/JPG/SVG via Rich record + cairosvg).  Extracte, Render the cockpit to ``path`` (PNG/JPG/SVG). Returns the written path.      gra, save_screenshot(), _add_topic_row(), _pane_border(), pick_breakpoint(), Panel (+86 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.15
 Nodes (15): ClaudeCodeAdapter, Built-in Claude Code adapter: per-role denies via a ``--settings`` overlay., _env_prefix(), external_restriction(), is_interactive(), Fully config-driven adapter (the "bring your own harness" path)., Register an adapter class under its ``type`` name (called at import time     fro, Build the shared ``env ...`` command prefix.      Two layers: juggle exports its (+7 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.06
-Nodes (31): Apply incremental schema migrations 1-35 (20+ live in migrations_recent)., Apply incremental schema migrations 1-35 (20+ live in migrations_recent)., Apply incremental schema migrations 1-34., run_migrations(), _next_excel_label(), Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ., Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ., Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ. (+23 more)
+Cohesion: 0.08
+Nodes (24): Apply incremental schema migrations 1-35 (20+ live in migrations_recent)., Apply incremental schema migrations 1-35 (20+ live in migrations_recent)., Apply incremental schema migrations 1-34., run_migrations(), _next_excel_label(), Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ., Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ., Return first unused Excel-style base-26 label: A..Z, AA..AZ, BA..ZZ. (+16 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.11
@@ -1704,7 +1718,7 @@ Nodes (30): JuggleDB tests: archive_thread, get_archive_candidates, unarchive_th
 
 ### Community 19 - "Community 19"
 Cohesion: 0.10
-Nodes (41): cmd_complete_agent(), cmd_complete_agent(), Mark agent complete: thread → closed, create notifications_v2 row,     convert a, Mark agent complete: thread → closed, create notifications_v2 row,     convert a, cmd_release_agent(), Mark agent complete: thread → closed, create notifications_v2 row,     convert a, Mark agent complete: thread → closed, create notifications_v2 row,     convert a, db() (+33 more)
+Nodes (40): cmd_complete_agent(), cmd_complete_agent(), Mark agent complete: thread → closed, create notifications_v2 row,     convert a, Mark agent complete: thread → closed, create notifications_v2 row,     convert a, Mark agent complete: thread → closed, create notifications_v2 row,     convert a, Mark agent complete: thread → closed, create notifications_v2 row,     convert a, db(), _no_keyword_items() (+32 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.09
@@ -1720,11 +1734,11 @@ Nodes (23): dogfood run() exits early (rc=1) when agents are busy, dogfood run()
 
 ### Community 23 - "Community 23"
 Cohesion: 0.01
-Nodes (295): MouseDown, MouseUp, Resize, Record pending user decisions in current thread's open_questions., Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, Clear pending decisions by tool_use_id prefix., Record pending user decisions in current thread's open_questions., Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With - (+287 more)
+Nodes (185): Record pending user decisions in current thread's open_questions., Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, Clear pending decisions by tool_use_id prefix., Record pending user decisions in current thread's open_questions., Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, Record pending user decisions in current thread's open_questions., Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With - (+177 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.27
-Nodes (16): make_db(), test_assigned_by_default_auto(), test_assigned_by_migration_idempotent(), test_count_threads_by_project(), test_create_project_returns_p_label(), test_get_active_projects_excludes_inbox(), test_get_dirty_projects_excludes_clean(), test_get_human_assigned_threads_by_project() (+8 more)
+Cohesion: 0.08
+Nodes (40): hooked_db(), _open_questions(), Tests for open_questions tracking via the AskUserQuestion hooks.  The live path, Real DB wired into the hook module via get_db()/is_active() overrides.      Avoi, Real DB wired into the hook module via get_db()/is_active() overrides.      Avoi, test_post_tool_use_clears_open_questions(), test_pre_tool_use_records_open_questions(), test_pre_tool_use_skips_when_no_current_thread() (+32 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.17
@@ -1739,8 +1753,8 @@ Cohesion: 0.17
 Nodes (25): fake_settings(), Tests for juggle_agent_settings.py — per-role Claude Code settings overlays.  Th, Building one role's overlay must not pollute another's (no shared refs)., Every agent role must get editorMode==normal in its overlay.      Uses the REAL, audit_mode strips per-role deny but must NOT remove editorMode.      Patches onl, write_agent_overlay must write editorMode==normal into the JSON file., Inject a controlled settings dict into juggle_agent_settings.get_settings., With only deny configured the overlay must contain ONLY permissions.deny —     n (+17 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.17
-Nodes (23): _bind_running_thread(), _complete(), _mk_graph(), _mk_task(), Tests for autopilot Phase 1 marking: complete-agent → task events (notify only,, `juggle graph mark-task t1 --handoff '…'` walks the task to 'verified'     via t, a → b (b depends on a)., a → b (b depends on a). (+15 more)
+Cohesion: 0.13
+Nodes (28): _bind_running_thread(), _complete(), _mk_graph(), _mk_task(), Tests for autopilot Phase 1 marking: complete-agent → task events (notify only,, --handoff must be wired into the complete-agent parser., --handoff must be wired into the complete-agent parser., --handoff must be wired into the complete-agent parser. (+20 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.16
@@ -1811,16 +1825,16 @@ Cohesion: 0.09
 Nodes (12): _clear_agent_env(), Tests for Task 5 tiered context injection., Prevent JUGGLE_IS_AGENT=1 (set in agent Claude sessions) from tainting orchestra, Session with no watermark gets at most 5 most-recent notifications., Session with no watermark gets at most 5 most-recent notifications., Session with watermark only sees notifications added after it., Session with watermark only sees notifications added after it., Two CLAUDE_CODE_SESSION_IDs each get their own independent watermark. (+4 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.36
-Nodes (8): hooked_db(), _open_questions(), Tests for open_questions tracking via the AskUserQuestion hooks.  The live path, Real DB wired into the hook module via get_db()/is_active() overrides.      Avoi, Real DB wired into the hook module via get_db()/is_active() overrides.      Avoi, test_post_tool_use_clears_open_questions(), test_pre_tool_use_records_open_questions(), test_pre_tool_use_skips_when_no_current_thread()
+Cohesion: 0.03
+Nodes (103): MouseDown, MouseUp, ComposeResult, Return (offsets_copy, active_pane) atomically., Atomically write column_ratios to config.json.      No-op if config file is miss, Atomically write column_ratios to config.json.      No-op if config file is miss, Create and initialise a JuggleDB for the cockpit.      snapshot() opens its own, Create and initialise a JuggleDB for the cockpit.      snapshot() opens its own (+95 more)
 
 ### Community 47 - "Community 47"
 Cohesion: 0.38
 Nodes (5): Regression test: DB_PATH is invariant under CLAUDE_PLUGIN_DATA., Verify DB_PATH doesn't change when CLAUDE_PLUGIN_DATA env var is set., Verify DB_PATH is absolute and properly expanded., test_db_path_ignores_claude_plugin_data(), test_db_path_resolves_absolute()
 
 ### Community 48 - "Community 48"
-Cohesion: 0.02
-Nodes (83): Connection, _is_junk_message(), Transition a thread to a new state ({'active','running','closed','archived'})., Update last_active_at to now without changing status., Return all threads matching the given status. Order: last_active_at DESC., Set status='archived', show_in_list=0. Preserves user_label., All projects including closed, with thread_count. Used for project list command., Active projects excluding INBOX — used for LLM assignment prompts. (+75 more)
+Cohesion: 0.03
+Nodes (39): Transition a thread to a new state ({'active','running','closed','archived'})., Update last_active_at to now without changing status., Return all threads matching the given status. Order: last_active_at DESC., Set status='archived', show_in_list=0. Preserves user_label., All projects including closed, with thread_count. Used for project list command., Active projects excluding INBOX — used for LLM assignment prompts., All projects including closed, with thread_count. Used for project list command., Load messages newest-first until token budget is exhausted         (token estima (+31 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.60
@@ -1835,8 +1849,8 @@ Cohesion: 0.50
 Nodes (3): isolated_schedule_env(), Conftest for schedule tests — sets _JUGGLE_TEST_DB to an in-memory path., Redirect DB, state file, and reports dir for each test.
 
 ### Community 52 - "Community 52"
-Cohesion: 0.08
-Nodes (25): _make_scrollable_db(), j/k keyboard scroll must still work after mouse-scroll handler rename., j/k keyboard scroll must still work after mouse-scroll handler rename., j/k keyboard scroll must still work after mouse-scroll handler rename., j/k keyboard scroll must still work after mouse-scroll handler rename., Return a db_path with n_threads so panes have enough rows to scroll past clamp., Return a db_path with n_threads so panes have enough rows to scroll past clamp., Posting MouseScrollDown must increment the active pane's offset by 1.      RED b (+17 more)
+Cohesion: 0.07
+Nodes (20): _is_junk_message(), _next_excel_label(), Count user messages for a thread, optionally excluding junk., Count user messages for a thread, optionally excluding junk., Return the last n Q/A pairs for a thread, most recent first.          Each item:, Return the last n Q/A pairs for a thread, most recent first.          Each item:, Return threads where substantive user message delta >= threshold.          Uses, Return threads where substantive user message delta >= threshold.          Uses (+12 more)
 
 ### Community 53 - "Community 53"
 Cohesion: 0.18
@@ -1859,20 +1873,20 @@ Cohesion: 0.15
 Nodes (22): parse_summary_response(), Parse LLM response into {{context, why, what, result}}. Pure function., Parse LLM response into {context, why, what, result}. Pure function.      Robust, _all_filled(), Regression pin (2026-06-17): parse_summary_response failed on markdown-wrapped h, CONTEXT: (uppercase) should also parse., Context - text (dash instead of colon) style., summarize_topic must return non-empty sections when LLM emits markdown headers. (+14 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.09
-Nodes (29): backfill_mirror_topics(), mirror_delete_thread(), _mirror_state(), mirror_upsert_thread(), dbops.db_mirror — mirror-topic projection for graph-mirrors-threads (Option 1)., Idempotent backfill: create/update mirror topics for all non-archived     thread, Sync mirror topics for one project.      - Upsert mirrors for all live (non-term, Create or update the mirror topic for ``thread_id`` in ``project_id``.      Sing (+21 more)
+Cohesion: 0.08
+Nodes (34): backfill_mirror_topics(), mirror_delete_thread(), _mirror_state(), mirror_upsert_thread(), dbops.db_mirror — mirror-topic projection for graph-mirrors-threads (Option 1)., Idempotent backfill: create/update mirror topics for all non-archived     thread, Sync mirror topics for one project.      - Upsert mirrors for all live (non-term, Create or update the mirror topic for ``thread_id`` in ``project_id``.      Sing (+26 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.10
 Nodes (43): _bind_merged(), db(), _mk_busy_agent(), _mk_project(), _mk_task(), _mk_topic(), JuggleDB, Path (+35 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.14
-Nodes (28): _canonical_main_ref(), Return the best canonical main ref for ``repo``.      Prefers origin/<main> afte, Record the merged commit (``ref`` tip, now on main) on the topic bound to     th, _record_merged_sha(), _add_commit(), _git(), _make_repo(), _make_repo_with_remote() (+20 more)
+Cohesion: 0.15
+Nodes (26): Record the merged commit (``ref`` tip, now on main) on the topic bound to     th, _record_merged_sha(), _add_commit(), _git(), _make_repo(), _make_repo_with_remote(), _make_simple_db(), _make_worktree() (+18 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.08
-Nodes (42): cmd_get_agent(), cmd_decommission_agent(), cmd_get_agent(), cmd_list_agents(), cmd_spawn_agent(), juggle_cmd_agents_lifecycle — Agent pool lifecycle commands.  Owns: cmd_get_agen, _get_args(), Regression tests for get-agent busy-guard (2026-06-15).  Symptom: get-agent ZT r (+34 more)
+Cohesion: 0.10
+Nodes (38): cmd_get_agent(), cmd_get_agent(), _get_args(), Regression tests for get-agent busy-guard (2026-06-15).  Symptom: get-agent ZT r, cas_assign_agent returns False when assigned_thread IS NOT NULL, even if idle., cmd_get_agent must spawn fresh when only busy agents exist.      2026-06-15: get, cmd_get_agent spawns fresh when CAS assign fails (TOCTOU guard).      2026-06-15, A busy agent is never included in the ranked-idle list.      2026-06-15: get-age (+30 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.13
@@ -1915,8 +1929,8 @@ Cohesion: 0.20
 Nodes (5): Returns empty dict when STATE_FILE doesn't exist, Returns dict contents when STATE_FILE exists, Returns empty dict when JSON is invalid, Returns empty dict when file read raises exception, TestLoadState
 
 ### Community 258 - "Community 258"
-Cohesion: 0.10
-Nodes (25): cmd_integrate(), get_db(), _graph_node_for_thread(), _graph_task_for_thread(), _pid_alive(), Atomic fetch → rebase → test → ff-merge → push → cleanup for a worktree.      Fa, Atomic fetch → rebase → test → ff-merge → push → cleanup for a worktree.      Fa, Graph task bound to this thread, or None (pre-migration DB, Mock db). (+17 more)
+Cohesion: 0.08
+Nodes (35): acquire_repo_lock(), _canonical_main_ref(), cmd_integrate(), get_db(), _get_lock_path(), _graph_node_for_thread(), _graph_task_for_thread(), _pid_alive() (+27 more)
 
 ### Community 296 - "Community 296"
 Cohesion: 0.10
@@ -1955,8 +1969,8 @@ Cohesion: 0.09
 Nodes (46): _args(), _diamond(), Tests for `juggle graph add-task` (single-task mid-execution graph insert).  Cov, --required-by a that closes a→b→...→a would form a loop: a depends on x,     x d, GUARD PIN: a --required-by target in a protected state (running) is     refused, GUARD PIN: a --required-by target that is already 'verified' is refused     (it, GUARD PIN: a --required-by target in a mutable state (here d is pending)     is, GUARD PIN: a --required-by target that was 'ready' must be demoted to     'pendi (+38 more)
 
 ### Community 602 - "Community 602"
-Cohesion: 0.27
-Nodes (19): claude_p(), days_ago_iso(), db_query(), Run `claude -p <prompt>` and return stdout. Updates cost_tracker if provided., Run `claude -p <prompt>` and return stdout. Updates cost_tracker if provided., _build_digest(), _file_reflect_issues(), _find_autofix_pr_ref() (+11 more)
+Cohesion: 0.31
+Nodes (17): claude_p(), days_ago_iso(), db_query(), Run `claude -p <prompt>` and return stdout. Updates cost_tracker if provided., Run `claude -p <prompt>` and return stdout. Updates cost_tracker if provided., _build_digest(), _find_autofix_pr_ref(), rf1_watchdog() (+9 more)
 
 ### Community 612 - "Community 612"
 Cohesion: 0.11
@@ -1979,16 +1993,16 @@ Cohesion: 0.10
 Nodes (11): JuggleDB tests: messages, token budget, summarized counts, stale threads, recent, get_recent_exchanges skips junk user messages., get_recent_exchanges returns None assistant when none exists yet., get_recent_exchanges returns empty list when no messages., get_recent_exchanges respects n parameter., get_recent_exchanges returns last n Q/A pairs, most recent first., test_get_recent_exchanges_basic(), test_get_recent_exchanges_empty() (+3 more)
 
 ### Community 707 - "Community 707"
-Cohesion: 0.10
-Nodes (16): Refresh the orchestrator session heartbeat timestamp to now., Return the timestamp when the orchestrator session was last registered., Public helper to write a session key (for tests)., Refresh the orchestrator session heartbeat timestamp to now., Public helper to write a session key (for tests)., Mixin for session-scoped state (active flag, current thread, settings)., Return True if session.active == '1'., Return a value from the settings table, or default if not found. (+8 more)
+Cohesion: 0.09
+Nodes (17): dbops.session — Session-key helpers mixin for JuggleDB.  Owns: reading/writing t, Refresh the orchestrator session heartbeat timestamp to now., Return the timestamp when the orchestrator session was last registered., Public helper to write a session key (for tests)., Refresh the orchestrator session heartbeat timestamp to now., Public helper to write a session key (for tests)., Mixin for session-scoped state (active flag, current thread, settings)., Return True if session.active == '1'. (+9 more)
 
 ### Community 773 - "Community 773"
-Cohesion: 0.08
-Nodes (25): build_project_arm_rows(), _HelpModal, ProjectArmRow, Juggle Cockpit — Textual modal screens.  Extracted from juggle_cockpit.py for mo, Help overlay listing all bindings, generated from CockpitApp.BINDINGS., Help overlay — grouped keyboard shortcuts with full descriptions., Help overlay — grouped keyboard shortcuts with full descriptions., Help overlay — grouped keyboard shortcuts with full descriptions. (+17 more)
+Cohesion: 0.11
+Nodes (16): _HelpModal, ProjectArmRow, Juggle Cockpit — Textual modal screens.  Extracted from juggle_cockpit.py for mo, Help overlay listing all bindings, generated from CockpitApp.BINDINGS., Help overlay — grouped keyboard shortcuts with full descriptions., Help overlay — grouped keyboard shortcuts with full descriptions., Help overlay — grouped keyboard shortcuts with full descriptions., Help overlay listing all bindings, generated from CockpitApp.BINDINGS. (+8 more)
 
 ### Community 778 - "Community 778"
-Cohesion: 0.06
-Nodes (45): build_hydration(), CapacityError, claim_node(), claim_task(), _dispatch_flat_task_fallback(), _dispatch_via_pool(), get_armed_project(), _give_up_dispatch() (+37 more)
+Cohesion: 0.14
+Nodes (18): build_hydration(), claim_node(), claim_task(), _dispatch_flat_task_fallback(), _give_up_dispatch(), _hydrate_for_node(), Exception, juggle_graph_dispatch — watchdog-owned graph dispatcher (autopilot Phase 2).  Ow (+10 more)
 
 ### Community 793 - "Community 793"
 Cohesion: 0.08
@@ -2024,19 +2038,19 @@ Nodes (26): _args(), Tests for juggle_cmd_graph — `juggle project-graph load` 
 
 ### Community 801 - "Community 801"
 Cohesion: 0.05
-Nodes (38): from_config(), HindsightError, _hs(), _paths(), Hindsight HTTP API client for Juggle memory integration.  All Hindsight communic, Request with one retry after auto-restart on failure., Attempt to restart the juggle-hindsight Docker service., Append error to log file. (+30 more)
+Nodes (39): from_config(), HindsightError, _hs(), _paths(), Hindsight HTTP API client for Juggle memory integration.  All Hindsight communic, Request with one retry after auto-restart on failure., Attempt to restart the juggle-hindsight Docker service., Append error to log file. (+31 more)
 
 ### Community 802 - "Community 802"
-Cohesion: 0.10
-Nodes (22): _get_oneshot_child_pid(), _get_pane_start_time(), _harness_markers(), oneshot_agent_alive(), _pane_has_juggle_agent_env(), Return ``(readiness, submission)`` marker tuples for the default harness.      R, Return ``(readiness, submission)`` marker tuples for the default harness.      R, Dispatch a task to a NON-interactive harness as a one-shot process.          Sim (+14 more)
+Cohesion: 0.09
+Nodes (24): cmd_list_agents(), cmd_list_agents(), cmd_spawn_agent(), juggle_cmd_agents_pool — Agent pool spawn/list/status commands.  Owns: cmd_spawn, _get_oneshot_child_pid(), _get_pane_start_time(), oneshot_agent_alive(), _pane_has_juggle_agent_env() (+16 more)
 
 ### Community 803 - "Community 803"
 Cohesion: 0.11
-Nodes (14): _LateBodyHandle, Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Fake CockpitHandle whose body paints only on the 3rd frame() call —     models t, Regression pin (2026-06-10): `cockpit --smoke --all-viewports` captured a     si, Fake CockpitHandle whose body paints only on the 3rd frame() call —     models t (+6 more)
+Nodes (14): _LateBodyHandle, Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Fake CockpitHandle whose body paints only on the 3rd frame() call —     models t, Regression pin (2026-06-10): `cockpit --smoke --all-viewports` captured a     si, Fake CockpitHandle whose body paints only on the 3rd frame() call —     models t (+6 more)
 
 ### Community 804 - "Community 804"
-Cohesion: 0.05
-Nodes (60): Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Match query against topic.label (case-insensitive). Returns Topic or None., Match query against topic.label (case-insensitive). Returns Topic or None., Match query against topic.label (case-insensitive). Returns Topic or None., resolve_task_detail() (+52 more)
+Cohesion: 0.06
+Nodes (47): Match query against topic.label (case-insensitive). Returns Topic or None., Match query against topic.label (case-insensitive). Returns Topic or None., Match query against topic.label (case-insensitive). Returns Topic or None., resolve_thread_detail(), _make_topic(), TDD tests for the T hotkey task-detail modal feature.  Covers:   1. resolve_task, CockpitApp.BINDINGS must have a binding for action 'task_detail'., resolve_thread_detail returns the Topic whose label matches the query. (+39 more)
 
 ### Community 805 - "Community 805"
 Cohesion: 0.13
@@ -2051,8 +2065,8 @@ Cohesion: 0.13
 Nodes (22): _create_worktree(), Create an isolated git worktree for a thread.      Returns (success, worktree_pa, _create_worktree(), _main_worktree_root(), juggle_cmd_agents_worktree — Git worktree helpers for agent dispatch/completion., Create an isolated git worktree for a thread.      Returns (success, worktree_pa, Pre-register worktree_path in ~/.claude.json projects map.      claude --dangero, Resolve ``repo_path`` to the MAIN worktree root.      Critical for nested-dispat (+14 more)
 
 ### Community 820 - "Community 820"
-Cohesion: 0.04
-Nodes (110): _apply_filter_actions(), _apply_filter_text(), _new_blocker_actions(), _newly_failed_agents(), _parse_filter(), Juggle Cockpit — pure module-level helpers and constants.  Extracted from juggle, Generic text-substring filter for Agent and Notification lists.      Matches aga, Return tier-0 (blocker) actions whose id was not in prev_ids. (+102 more)
+Cohesion: 0.03
+Nodes (129): _apply_filter_actions(), _apply_filter_text(), _new_blocker_actions(), _newly_failed_agents(), _parse_filter(), Juggle Cockpit — pure module-level helpers and constants.  Extracted from juggle, Generic text-substring filter for Agent and Notification lists.      Matches aga, Return tier-0 (blocker) actions whose id was not in prev_ids. (+121 more)
 
 ### Community 821 - "Community 821"
 Cohesion: 0.15
@@ -2079,12 +2093,12 @@ Cohesion: 0.11
 Nodes (24): JuggleTmuxManager, _capture_pane(), _cleanup_singleton_pid(), _get_dirs(), _is_pid_alive_local(), main(), prune_stale_watchdog_pidfiles(), JuggleDB (+16 more)
 
 ### Community 827 - "Community 827"
-Cohesion: 0.11
-Nodes (15): Read-only detail overlay for a thread/topic.      Shows label, title, status, an, Read-only detail overlay for a thread/topic.      Shows label, title, status, an, Read-only detail overlay for a thread/topic.      Header (label/title/state) ren, Read-only detail overlay for a thread/topic.      Header (label/title/state) ren, Fallback body when LLM summary is unavailable., Fallback body when LLM summary is unavailable., Render the four LLM sections + recent activity., Render the four LLM sections + recent activity. (+7 more)
+Cohesion: 0.14
+Nodes (13): Read-only detail overlay for a thread/topic.      Shows label, title, status, an, Read-only detail overlay for a thread/topic.      Shows label, title, status, an, Read-only detail overlay for a thread/topic.      Header (label/title/state) ren, Read-only detail overlay for a thread/topic.      Header (label/title/state) ren, Fallback body when LLM summary is unavailable., Fallback body when LLM summary is unavailable., Render the four LLM sections + recent activity., Render the four LLM sections + recent activity. (+5 more)
 
 ### Community 828 - "Community 828"
-Cohesion: 0.06
-Nodes (30): _normalize_title_str(), _normalize_title_tokens(), Tokenize to significant content words: drop verbs, stopwords, len-1 tokens., Token-set Jaccard similarity with numbered-series guard.      Normalise → drop a, Lowercase, strip a leading graph-topic prefix, drop punctuation and     stopword, Lexical title similarity in 0..1.      Score = max(token-set containment |A∩B|/m, Return a normalized bare string for sequence-marker comparison., Strip trailing sequence marker. Returns (base, marker_or_empty). (+22 more)
+Cohesion: 0.11
+Nodes (18): _normalize_title_str(), _normalize_title_tokens(), dbops.threads — Thread CRUD, state machine, archive, and stale-query mixin.  Own, Tokenize to significant content words: drop verbs, stopwords, len-1 tokens., Token-set Jaccard similarity with numbered-series guard.      Normalise → drop a, Lowercase, strip a leading graph-topic prefix, drop punctuation and     stopword, Lexical title similarity in 0..1.      Score = max(token-set containment |A∩B|/m, Return a normalized bare string for sequence-marker comparison. (+10 more)
 
 ### Community 829 - "Community 829"
 Cohesion: 0.12
@@ -2095,24 +2109,24 @@ Cohesion: 0.13
 Nodes (28): assign_ranks(), build_ranks(), GraphNode, Map node id -> rank, rank = longest dependency depth (longest path).      Cycle-, Map task id -> rank, rank = longest dependency depth (longest path).      Cycle-, Group nodes into ordered Rank columns (stable by node id within a rank)., Group tasks into ordered Rank columns (stable by task id within a rank)., _n() (+20 more)
 
 ### Community 831 - "Community 831"
-Cohesion: 0.19
-Nodes (13): Display counts over graph_topics (same shape as juggle_graph_status)., Display counts over graph_topics (same shape as juggle_graph_status)., topic_counts(), build_graph_injection(), counts_from_states(), format_progress(), graph_counts(), juggle_graph_status — read-only display aggregates over graph_tasks.  Owns: per- (+5 more)
+Cohesion: 0.09
+Nodes (31): Display counts over graph_topics (same shape as juggle_graph_status)., Display counts over graph_topics (same shape as juggle_graph_status)., topic_counts(), _cmd_arm(), cmd_autopilot(), _cmd_remove(), _cmd_status(), _flag_set() (+23 more)
 
 ### Community 832 - "Community 832"
-Cohesion: 0.09
-Nodes (25): CockpitHandle, capture_body_frame(), check_overflow(), check_real_estate(), CockpitHandle, open_cockpit_pty(), Path, Juggle cockpit viewport smoke harness.  Mechanism: pty+pyte (primary). Spawns `j (+17 more)
+Cohesion: 0.10
+Nodes (24): CockpitHandle, cmd_cockpit(), Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, capture_body_frame(), check_chrome_present(), check_overflow(), check_real_estate(), Path (+16 more)
 
 ### Community 833 - "Community 833"
 Cohesion: 0.14
 Nodes (29): build_graph_panel(), Build the graph Panel. Pure — no I/O.      selection indexes the flat topologica, Build the graph Panel. Pure — no I/O.      selection indexes the flat topologica, _armed_many_db(), _dag(), TDD tests for the graph panel Rich renderable builder.  build_graph_panel turns, 2026-06-16 (user feedback + screenshot): the [thread/topic id] badge must     su, T-cockpit-graph-pane-ux #1: section header renders '<id> · <name>',     not just (+21 more)
 
 ### Community 834 - "Community 834"
-Cohesion: 0.12
-Nodes (31): acquire_repo_lock(), _get_lock_path(), Path, Acquire a per-repo file lock. Returns the lock path.      Steals locks with a de, Remove the lock only if owned by the current process., _read_lock(), release_repo_lock(), acquire_repo_lock() (+23 more)
+Cohesion: 0.14
+Nodes (25): Remove the lock only if owned by the current process., release_repo_lock(), acquire_repo_lock(), _get_lock_path(), _pid_alive(), Path, juggle_integrate_lock — per-repo merge-queue file lock for integrate.  Owns: loc, Remove the lock only if owned by the current process. (+17 more)
 
 ### Community 835 - "Community 835"
-Cohesion: 0.20
-Nodes (6): Return count of non-resolved error_events rows., Mixin for self-heal error_events table operations., Insert new error_events row or increment count on duplicate.          Returns ne, Update status (and optionally action_item_id) for an error_events row., Return all non-resolved error_events rows, newest last., SelfhealMixin
+Cohesion: 0.17
+Nodes (7): dbops.selfheal — Self-heal error_events mixin for JuggleDB.  Owns: dedup_or_inse, Return count of non-resolved error_events rows., Mixin for self-heal error_events table operations., Insert new error_events row or increment count on duplicate.          Returns ne, Update status (and optionally action_item_id) for an error_events row., Return all non-resolved error_events rows, newest last., SelfhealMixin
 
 ### Community 836 - "Community 836"
 Cohesion: 0.11
@@ -2131,8 +2145,8 @@ Cohesion: 0.18
 Nodes (12): _arm_graph(), _make_db(), Path, Seed an armed project + a small DAG so graph mode renders a real graph., Graph mode (press g) at 80x67 (2k_third) renders without overflow.      Headline, --out render with incident config [0.0,0.45,0.55] must produce non-empty topics, --out render with incident config [0.0,0.45,0.55] must produce non-empty topics, --out render with incident config [0.0,0.45,0.55] must produce non-empty topics (+4 more)
 
 ### Community 840 - "Community 840"
-Cohesion: 0.14
-Nodes (15): _classify_failure(), cmd_fail_agent(), _classify_failure(), juggle_cmd_agents_common — Shared symbols and pure classifiers for agent command, Return 'transient' or 'persistent'. Case-insensitive substring match., Return 'transient' or 'persistent'. Case-insensitive substring match., Route agent failure: transient → leave running for retry; persistent → action_it, Return 'transient' or 'persistent'. Case-insensitive substring match. (+7 more)
+Cohesion: 0.09
+Nodes (25): _classify_failure(), cmd_fail_agent(), _classify_failure(), juggle_cmd_agents_common — Shared symbols and pure classifiers for agent command, Return 'transient' or 'persistent'. Case-insensitive substring match., cmd_fail_agent(), juggle_cmd_agents_complete — Agent completion and failure handlers.  Owns: cmd_c, Route agent failure: transient → leave running for retry; persistent → action_it (+17 more)
 
 ### Community 841 - "Community 841"
 Cohesion: 0.14
@@ -2171,24 +2185,24 @@ Cohesion: 0.18
 Nodes (6): Connection, Return the most recent date stored for HN articles, or None., RRF fusion of vec0 KNN and FTS5. Returns top-k results., Insert article; skip if URL exists. Returns new row id or None., ResearchKB, _serialize_f32()
 
 ### Community 856 - "Community 856"
-Cohesion: 0.10
-Nodes (15): _col_names(), Tests for watchdog-related DB schema and methods., send-task writes last_task, last_send_task_pane_hash (16 hex chars), last_send_t, release-agent copies last_task/role/model to thread before decommissioning agent, test_agents_has_busy_since(), test_agents_has_last_activity_at(), test_agents_has_last_send_task_at(), test_agents_has_last_send_task_pane_hash() (+7 more)
+Cohesion: 0.11
+Nodes (13): _col_names(), Tests for watchdog-related DB schema and methods., send-task writes last_task, last_send_task_pane_hash (16 hex chars), last_send_t, test_agents_has_busy_since(), test_agents_has_last_activity_at(), test_agents_has_last_send_task_at(), test_agents_has_last_send_task_pane_hash(), test_agents_has_last_task() (+5 more)
 
 ### Community 857 - "Community 857"
 Cohesion: 0.09
 Nodes (21): `backfill_mirror_topics(db) → int`, Cockpit Changes, Critical Constraints, DA Resolutions, Doctor Integration, Graph Mirrors Threads — Option 1 Implementation Plan, Guard Bypass: `check_task_guard` in `juggle_cmd_agents_graph.py`, `juggle_cockpit_graph_dag.py` (+13 more)
 
 ### Community 858 - "Community 858"
-Cohesion: 0.16
-Nodes (21): apply_graph_migrations(), _cols(), _drop_old_task_indexes(), _merge_nodes_into_tasks(), migrate_is_mirror(), migrate_merged_sha(), _migrate_node_to_task(), migrate_runs_vcs() (+13 more)
+Cohesion: 0.18
+Nodes (18): _cols(), _drop_old_task_indexes(), _merge_nodes_into_tasks(), migrate_is_mirror(), migrate_merged_sha(), _migrate_node_to_task(), migrate_runs_vcs(), dbops.migrations_graph — autopilot graph/topic store migrations (35-37, 39).  Ow (+10 more)
 
 ### Community 859 - "Community 859"
 Cohesion: 0.09
 Nodes (25): get_dependents(), Dep ids of ``node_id`` whose state is not 'verified' (blocking deps)., Dep ids of ``node_id`` whose state is not 'verified' (blocking deps)., Node ids that depend on ``node_id`` (reverse edges)., Pending nodes of ``project_id`` whose deps are ALL 'verified'., Node ids that depend on ``node_id`` (reverse edges)., Dep ids of ``node_id`` whose state is not 'verified' (blocking deps)., Promote every eligible pending node to 'ready'. Returns newly-ready ids. (+17 more)
 
 ### Community 860 - "Community 860"
-Cohesion: 0.22
-Nodes (12): _agent_cfg(), TDD: spawn_agent and start_agent_in_pane must honor harness_override at launch., spawn_agent with no harness_override persists the config default harness., spawn_agent with reasonix override must NOT issue load-buffer to pane (non-inter, start_agent_in_pane with claude harness (interactive) writes + pastes a command., start_agent_in_pane with reasonix (non-interactive) must NOT paste any command., spawn_agent(harness_override='reasonix') must store harness='reasonix', not 'cla, test_spawn_agent_harness_override_persists_reasonix_on_agent_row() (+4 more)
+Cohesion: 0.19
+Nodes (14): _agent_cfg(), TDD: spawn_agent and start_agent_in_pane must honor harness_override at launch., spawn_agent with no harness_override persists the config default harness., spawn_agent with reasonix override must NOT issue load-buffer to pane (non-inter, cmd_send_task dispatches via the AGENT'S persisted harness, not config default., start_agent_in_pane with claude harness (interactive) writes + pastes a command., start_agent_in_pane with reasonix (non-interactive) must NOT paste any command., spawn_agent(harness_override='reasonix') must store harness='reasonix', not 'cla (+6 more)
 
 ### Community 861 - "Community 861"
 Cohesion: 0.12
@@ -2203,24 +2217,24 @@ Cohesion: 0.10
 Nodes (7): Tests for the durable agent I/O ledger (agent_runs table + RunsMixin).  The ledg, A DB created before the agent_runs migration gets the table on re-open., _seed(), test_existing_db_without_table_gets_it(), test_get_runs_filter_by_each_key(), test_get_runs_ordering_newest_first_and_limit(), test_prune_runs_deletes_only_older_than_cutoff()
 
 ### Community 864 - "Community 864"
-Cohesion: 0.14
-Nodes (26): cmd_send_task(), cmd_send_task(), Auto-create worktree uses agent.repo_path, not os.getcwd()., test_send_task_auto_create_uses_agent_repo_not_cwd(), REGRESSION PIN (DA B5, 2026-06-10): the autopilot LLM loop raced the     tick by, test_send_task_refuses_node_bound_thread_without_force(), test_send_task_refuses_task_bound_thread_without_force(), cmd_send_task dispatches via the AGENT'S persisted harness, not config default. (+18 more)
+Cohesion: 0.24
+Nodes (16): cmd_send_task(), _minimal_agent(), _minimal_send_task_args(), _minimal_thread(), Drive cmd_send_task with mocked DB and tmux/adapter., coder + repo_path → _create_worktree called, worktree fields persisted to thread, researcher role is exempt from auto-create., coder + repo_path + create fails + no --allow-main → exit(1). (+8 more)
 
 ### Community 865 - "Community 865"
 Cohesion: 0.12
 Nodes (14): MessagesMixin, Return the last n Q/A pairs for a thread, most recent first.          Each item:, Mixin for per-thread message CRUD and context-window queries., Load messages newest-first until token budget is exhausted         (token estima, Count user messages for a thread, optionally excluding junk., Return the last user message and last assistant message for a thread.          R, _is_junk_message(), Return True if content is a junk/system message to be excluded from display. (+6 more)
 
 ### Community 866 - "Community 866"
-Cohesion: 0.12
-Nodes (11): GraphModeMixin, Graph-mode controller mixin for the cockpit App.  Owns the lower-right panel's N, Enter — open the read-only detail modal for the selected topic/task., Handle a key in graph mode. Return True if consumed (don't bubble)., Provides graph-mode behaviour to CockpitApp., Initialise graph view-state. Call from __init__., Recompute the unread badge from the current snapshot (text-based so         it's, g — toggle the lower-right panel between Notifications and Graph. (+3 more)
+Cohesion: 0.08
+Nodes (24): MouseMove, Resize, GraphModeMixin, Graph-mode controller mixin for the cockpit App.  Owns the lower-right panel's N, Enter — open the read-only detail modal for the selected topic/task., Handle a key in graph mode. Return True if consumed (don't bubble)., Provides graph-mode behaviour to CockpitApp., Initialise graph view-state. Call from __init__. (+16 more)
 
 ### Community 867 - "Community 867"
 Cohesion: 0.15
 Nodes (6): Map changed files to the minimal set of test files that covers them.      Return, select_scoped_tests(), select_scoped_tests uses import_index as primary mapping strategy., TestCoreGlobs, TestImportReferenceMapping, TestSrcToTestMapping
 
 ### Community 868 - "Community 868"
-Cohesion: 0.11
-Nodes (37): _bind_running_thread(), _bind_running_topic(), _complete(), _merged_repo(), _mk_graph(), _mk_topic_task(), Tests for autopilot Phase 2 contracts: --handoff enforcement on complete-agent (, b has no dependents — the contract only binds tasks others consume. (+29 more)
+Cohesion: 0.14
+Nodes (31): _bind_running_thread(), _bind_running_topic(), _complete(), _merged_repo(), _mk_graph(), _mk_topic_task(), Tests for autopilot Phase 2 contracts: --handoff enforcement on complete-agent (, b has no dependents — the contract only binds tasks others consume. (+23 more)
 
 ### Community 869 - "Community 869"
 Cohesion: 0.25
@@ -2263,16 +2277,16 @@ Cohesion: 0.09
 Nodes (16): ComposeResult, ModalScreen, _ConfirmModal, _GraphNodeModal, _GraphTaskModal, ComposeResult, Single-keypress y/N confirm gate.      Dismisses True on 'y', False on 'n' or Es, Single-keypress y/N confirm gate.      Dismisses True on 'y', False on 'n' or Es (+8 more)
 
 ### Community 879 - "Community 879"
-Cohesion: 0.40
-Nodes (5): Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., test_nav_j_key_produces_visible_change()
+Cohesion: 0.17
+Nodes (12): open_cockpit_pty(), Spawn juggle_cockpit.py in a pty sized to (cols, rows) and return a handle., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Nav: pressing 'j' 10 times scrolls the topics pane — grid differs from initial., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs. (+4 more)
 
 ### Community 880 - "Community 880"
 Cohesion: 0.36
 Nodes (8): db_path(), kb(), test_fts_search_returns_results(), test_init_db_creates_tables(), test_insert_article(), test_insert_article_idempotent(), test_pdf_file_tracking(), test_upsert_embedding()
 
 ### Community 881 - "Community 881"
-Cohesion: 0.17
-Nodes (19): _dedupe_title(), _is_generic_title(), Lowercase alphanumeric tokens of a title with generic filler removed., True when a non-empty title is ALL filler — no specific content words.      Empt, True when two titles share the same set of content words.      Catches 'Improve, Disambiguate a title that is interchangeable with an existing topic's.      Appe, _title_content_words(), _titles_interchangeable() (+11 more)
+Cohesion: 0.28
+Nodes (12): _is_generic_title(), True when a non-empty title is ALL filler — no specific content words.      Empt, _cfg(), _db(), TDD: specific, non-duplicate auto topic-title generation.  User feedback (2026-0, Re-running generation for a thread must not dedupe against its own title., test_dedup_excludes_self(), test_generation_is_dedup_aware() (+4 more)
 
 ### Community 882 - "Community 882"
 Cohesion: 0.14
@@ -2283,8 +2297,8 @@ Cohesion: 0.08
 Nodes (21): _armed_graph_context(), autopilot_context(), juggle_hooks_autopilot — autopilot directive injection for UserPromptSubmit.  Ow, Return the autopilot directive if the flag file is set, else ''., Carve-out + budgeted graph status when a project is armed, else ''.      Authori, Carve-out + budgeted topic status for EVERY armed project, else \'\'.      Autho, Return the autopilot directive (+ armed-project context) if the flag     file is, Return the autopilot directive (+ armed-project context) if the flag     file is (+13 more)
 
 ### Community 884 - "Community 884"
-Cohesion: 0.15
-Nodes (17): build_hydration(), build_topic_hydration(), hydrate_for_node(), hydrate_for_task(), hydrate_for_topic(), juggle_graph_hydration — pure dispatch-prompt builder for graph tasks.  Owns: ``, DB wrapper: dep-topic rows + topo-ordered tasks → build_topic_hydration., Build a dispatch prompt for ``task`` from its plan + upstream handoffs.      Pur (+9 more)
+Cohesion: 0.22
+Nodes (10): build_hydration(), hydrate_for_node(), hydrate_for_task(), hydrate_for_topic(), juggle_graph_hydration — pure dispatch-prompt builder for graph tasks.  Owns: ``, DB wrapper: dep-topic rows + topo-ordered tasks → build_topic_hydration., Build a dispatch prompt for ``task`` from its plan + upstream handoffs.      Pur, Phase 2 deferred the integrated-branch diffstat from hydration; it is     now ca (+2 more)
 
 ### Community 885 - "Community 885"
 Cohesion: 0.20
@@ -2299,8 +2313,8 @@ Cohesion: 0.12
 Nodes (13): Popen, Watchdog singleton + prod-launch guard (2026-06-16 incident).  A coder running t, The destructive proc-spawning watchdog tests must be OPT-IN: a default     `pyte, Kill-all logic unit-tested against a MOCKED process list — no real     processes, find_watchdog_pids parses pgrep output and never returns our own pid —     exerc, End-to-end: simulate the live canonical watchdog (a process whose cmdline     ca, _spawn_marked(), test_default_run_does_not_kill_canonical_watchdog() (+5 more)
 
 ### Community 888 - "Community 888"
-Cohesion: 0.19
-Nodes (16): _ensure_dirs(), _ensure_gh_label(), gh_create_issue(), gh_issue_exists(), gh_pr_list_head(), gh_run(), last_run_ts(), load_state() (+8 more)
+Cohesion: 0.13
+Nodes (23): datetime, _ensure_dirs(), _ensure_gh_label(), get_db(), gh_create_issue(), gh_issue_exists(), gh_pr_list_head(), gh_run() (+15 more)
 
 ### Community 889 - "Community 889"
 Cohesion: 0.25
@@ -2319,36 +2333,36 @@ Cohesion: 0.33
 Nodes (4): Integration tests for state management, Save and load state roundtrip, Mark complete and retrieve timestamp, TestStateIntegration
 
 ### Community 893 - "Community 893"
-Cohesion: 0.11
-Nodes (14): datetime, dbops.agents — Agent pool and watchdog-events mixin for JuggleDB.  Owns: create/, dbops.messages — Message storage and context-window query mixin.  Owns: add_mess, dbops.migrations — Incremental SQLite schema migration runner.  Owns: ``run_migr, dbops.migrations_recent — schema migrations 20-39 + 41.  Owns: the second half o, dbops.notifications — Notifications v2 and action-items mixin.  Owns: add/query/, dbops.projects — Project CRUD and project-thread relationship mixin.  Owns: crea, dbops.runs — durable agent I/O ledger mixin for JuggleDB.  Owns: insert/close/su (+6 more)
+Cohesion: 0.10
+Nodes (14): dbops.agents — Agent pool and watchdog-events mixin for JuggleDB.  Owns: create/, dbops.messages — Message storage and context-window query mixin.  Owns: add_mess, dbops.migrations — Incremental SQLite schema migration runner.  Owns: ``run_migr, dbops.notifications — Notifications v2 and action-items mixin.  Owns: add/query/, dbops.projects — Project CRUD and project-thread relationship mixin.  Owns: crea, dbops.schema_graph — autopilot graph/topic store DDL (CREATE_* constants).  Owns, dbops.schema — DDL constants, module-level helpers, and shared config.  Owns: al, Parse last_active ISO timestamp, return seconds since now, or None. (+6 more)
 
 ### Community 894 - "Community 894"
 Cohesion: 0.13
 Nodes (20): _parse_psrecord_log(), _profile_worker_loop(), juggle_cockpit_profile — Headless profiling harness for the cockpit.  Owns: _par, Run the cockpit profiling harness.      Spawns a headless worker child (``--prof, Parse a psrecord log and return summary stats.      psrecord log format::, Run a headless snapshot+render loop for *duration* seconds.      Each iteration, run_profile(), TDD tests for cockpit --profile harness.  Covers:   1. _parse_psrecord_log: pars (+12 more)
 
 ### Community 895 - "Community 895"
-Cohesion: 0.17
-Nodes (12): _bind_merged_topic(), db(), _merged_repo(), JuggleDB, Path, REGRESSION PIN (2026-06-10): _dispatch_via_pool must pass db.db_path to     cmd_, REGRESSION PIN (2026-06-10): _dispatch_via_pool must pass db.db_path to     cmd_, A real repo whose 'main' branch satisfies the G1 verified⟺merged guard. (+4 more)
+Cohesion: 0.15
+Nodes (13): db(), JuggleDB, REGRESSION PIN (2026-06-10): create_thread on db1 must be visible via     get_th, REGRESSION PIN (2026-06-10): create_thread on db1 must be visible via     get_th, REGRESSION PIN (2026-06-10): _dispatch_via_pool must pass db.db_path to     cmd_, REGRESSION PIN (2026-06-10): _dispatch_via_pool must pass db.db_path to     cmd_, REGRESSION PIN (DA round-2 minor 2, 2026-06-10): _dispatch_via_pool     released, REGRESSION PIN (DA round-2 minor 2, 2026-06-10): _dispatch_via_pool     released (+5 more)
 
 ### Community 896 - "Community 896"
-Cohesion: 0.11
-Nodes (24): cmd_doctor(), _migrate_config(), Juggle CLI — `doctor` subcommand: migrate config + DB to current schema., Pure helper: rewrite a config dict from the pre-1.21.0 schema to 1.21+.      Ret, _make_current_db(), Path, Tests for juggle doctor config migration helper., REGRESSION PIN (2026-06-15): doctor skipped init_db when schema appeared     'cu (+16 more)
+Cohesion: 0.16
+Nodes (15): cmd_doctor(), _migrate_config(), Juggle CLI — `doctor` subcommand: migrate config + DB to current schema., Pure helper: rewrite a config dict from the pre-1.21.0 schema to 1.21+.      Ret, Tests for juggle doctor config migration helper., If user has already set paths.vault, do not overwrite it., If user has already set paths.vault, do not overwrite it., domains block without a 'vault' path: still strip block, leave paths alone. (+7 more)
 
 ### Community 897 - "Community 897"
 Cohesion: 0.16
 Nodes (19): _bind_merged(), db(), JuggleDB, Path, dbops.db_topics — topic CRUD, shared state machine, DERIVED topic deps (task edg, T-verified-merged-sha: topic→verified requires a recorded merged_sha that     is, Topic A depends on topic B iff any task of A has an edge to a task of B.     Int, The agent executes tasks sequentially in intra-topic dependency order. (+11 more)
 
 ### Community 898 - "Community 898"
-Cohesion: 0.10
-Nodes (31): check_chrome_present(), check_truncation(), load_viewports(), Count ellipsis (…) truncation markers across all rows.      Returns {"warn": boo, Header (top 3 rows) and footer (bottom 3 rows) must render.      Header marker:, Count ellipsis (…) truncation markers across all rows.      Returns {"warn": boo, Load viewport profiles from a YAML file.      Returns dict[name -> {"cols": int,, Load viewport profiles from a YAML file.      Returns dict[name -> {"cols": int, (+23 more)
+Cohesion: 0.15
+Nodes (22): check_truncation(), load_viewports(), Count ellipsis (…) truncation markers across all rows.      Returns {"warn": boo, Count ellipsis (…) truncation markers across all rows.      Returns {"warn": boo, Load viewport profiles from a YAML file.      Returns dict[name -> {"cols": int,, Load viewport profiles from a YAML file.      Returns dict[name -> {"cols": int,, _make_grid(), Tests for the cockpit viewport smoke harness (juggle_smoke).  Pure heuristic and (+14 more)
 
 ### Community 899 - "Community 899"
 Cohesion: 0.12
 Nodes (15): Acceptance, Circuit breaker (short-TTL), Cost + observability, Current-state verdict, Design, Devil's Advocate, Enforcement — CI guard test (the anti-drift mechanism), Fallback chain + error taxonomy (+7 more)
 
 ### Community 900 - "Community 900"
-Cohesion: 0.16
-Nodes (23): get_db(), git_commit(), git_push(), write_report(), _build_report(), _check_active_session(), _check_prior_dogfood_thread(), _ensure_reports_dir() (+15 more)
+Cohesion: 0.17
+Nodes (22): git_commit(), git_push(), write_report(), _build_report(), _check_active_session(), _check_prior_dogfood_thread(), _ensure_reports_dir(), _file_action_item() (+14 more)
 
 ### Community 901 - "Community 901"
 Cohesion: 0.12
@@ -2363,8 +2377,8 @@ Cohesion: 0.15
 Nodes (14): _clamp_col_pct(), _clamp_col_pct(), Clamp an integer percent to [lo, hi].  Prevents 0% or 100% topics., _cockpit_subtitle(), _get_version(), Cockpit title-bar version (single source of truth: .claude-plugin/plugin.json)., Read the juggle version from plugin.json. Returns '?' on failure., Build the Header sub_title with the version appended.      Wide: "Cockpit v2 · v (+6 more)
 
 ### Community 904 - "Community 904"
-Cohesion: 0.14
-Nodes (20): close_adhoc_run(), enforce_handoff_contract(), fail_graph_node(), fail_graph_task(), mark_graph_node(), _node_for_thread(), _notify_failure(), juggle_cmd_agents_graph — graph-task glue for the agent CLI (autopilot).  Owns: (+12 more)
+Cohesion: 0.09
+Nodes (31): check_node_guard(), check_task_guard(), close_adhoc_run(), enforce_handoff_contract(), fail_graph_node(), fail_graph_task(), mark_graph_node(), _node_for_thread() (+23 more)
 
 ### Community 905 - "Community 905"
 Cohesion: 0.50
@@ -2383,16 +2397,16 @@ Cohesion: 0.40
 Nodes (4): juggle_cli_parsers_threads — Subparser registration for thread/session commands., Register thread/session subcommands on the given subparsers object., Register thread/session subcommands on the given subparsers object., register()
 
 ### Community 909 - "Community 909"
-Cohesion: 0.24
-Nodes (13): db(), _flat_node(), _flat_task(), _migrate(), JuggleDB, Path, Migration 37 — graph_topics backfill (3-tier R9, 2026-06-11).  REGRESSION-CRITIC, REGRESSION PIN (2026-06-11): flat→3-tier. Task state, thread binding,     and up (+5 more)
+Cohesion: 0.33
+Nodes (10): _flat_node(), _flat_task(), _migrate(), Migration 37 — graph_topics backfill (3-tier R9, 2026-06-11).  REGRESSION-CRITIC, REGRESSION PIN (2026-06-11): flat→3-tier. Task state, thread binding,     and up, A task literally named 'T-z' must not abort the migration when task 'z'     also, test_backfill_collision_uses_alternate_id(), test_backfill_is_idempotent() (+2 more)
 
 ### Community 910 - "Community 910"
-Cohesion: 0.33
-Nodes (6): _age_secs(), Return seconds since last_active ISO timestamp, or 0 if unparseable., Return seconds since last_active ISO timestamp, or 0 if unparseable., Return seconds since last_active ISO timestamp, or 0 if unparseable., Return seconds since last_active ISO timestamp, or 0 if unparseable., Return seconds since last_active ISO timestamp, or 0 if unparseable.
+Cohesion: 0.13
+Nodes (18): _age_secs(), fetch_scheduled_tasks(), group_threads_by_project(), _launchctl_status(), _parse_schedule(), Juggle Cockpit Model — DB reads → typed frozen dataclasses. Zero Rich imports., Return (pid, last_exit_status) for a launchd label., Discover scheduled tasks via the platform-appropriate backend. (+10 more)
 
 ### Community 911 - "Community 911"
-Cohesion: 0.22
-Nodes (11): Regression tests for JH incident bugs.  Bug 1: Watchdog false-positives undispat, After release, agent's last_task/last_send_task_at must be NULL; thread gets cop, Busy agent with last_send_task_at=None must not be classified as stalled., Dispatched agents with stale content still classify as stalled (no regression)., Recovery on agent with last_task=None must not invoke send_task.      Main behav, RuntimeError from send_task must be caught; poll loop must not crash., test_classify_pane_state_awaiting_dispatch_when_never_dispatched(), test_classify_pane_state_stalled_when_dispatched() (+3 more)
+Cohesion: 0.18
+Nodes (9): cmd_decommission_agent(), cmd_list_agents(), cmd_release_agent(), cmd_spawn_agent(), juggle_cmd_agents_lifecycle — Agent pool lifecycle commands.  Owns: cmd_get_agen, release-agent copies last_task/role/model to thread before decommissioning agent, test_release_agent_copies_dispatch_payload(), After release, agent's last_task/last_send_task_at must be NULL; thread gets cop (+1 more)
 
 ### Community 912 - "Community 912"
 Cohesion: 0.17
@@ -2411,12 +2425,12 @@ Cohesion: 0.09
 Nodes (21): Agent Harness, Cockpit, DB Mode (tmpfs), Env-only overrides (not in config.json), Global Limits, Harness adapters (`agent.harnesses.<name>`), Hindsight Memory, Integrate (CI / test runner) (+13 more)
 
 ### Community 916 - "Community 916"
-Cohesion: 0.14
-Nodes (10): _now(), Mark open runs for a thread or agent as 'failed' (watchdog kill path)., Return runs (newest-first), filtered by any provided key., Return a single run by id, or None., Delete rows dispatched more than older_than_days ago. Returns count., Mixin for the append-only agent_runs ledger., Insert a new ledger row in status 'dispatched'. Returns run_id.          The tra, Close the NEWEST open ('dispatched') run for thread_id.          Best-effort cap (+2 more)
+Cohesion: 0.13
+Nodes (11): _now(), dbops.runs — durable agent I/O ledger mixin for JuggleDB.  Owns: insert/close/su, Mark open runs for a thread or agent as 'failed' (watchdog kill path)., Return runs (newest-first), filtered by any provided key., Return a single run by id, or None., Delete rows dispatched more than older_than_days ago. Returns count., Mixin for the append-only agent_runs ledger., Insert a new ledger row in status 'dispatched'. Returns run_id.          The tra (+3 more)
 
 ### Community 917 - "Community 917"
 Cohesion: 0.02
-Nodes (110): App, CockpitApp, Generic one-line input modal. Dismisses with the stripped value or None.      di, Single-keypress y/N confirm gate.      Dismisses True on 'y', False on 'n' or Es, Help overlay listing all bindings, generated from CockpitApp.BINDINGS., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape. (+102 more)
+Nodes (115): App, CockpitApp, Generic one-line input modal. Dismisses with the stripped value or None.      di, Single-keypress y/N confirm gate.      Dismisses True on 'y', False on 'n' or Es, Help overlay listing all bindings, generated from CockpitApp.BINDINGS., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape., Intercept Tab/Shift+Tab before Textual focus traversal; clear filter on Escape. (+107 more)
 
 ### Community 918 - "Community 918"
 Cohesion: 0.20
@@ -2427,8 +2441,8 @@ Cohesion: 0.20
 Nodes (9): Brief — Multi-Project Parallel Autopilot, Constraints / non-goals, Current limitation (ground truth — verify in code), Deliverables expected from the Fable agent, Open questions for the spec agent to resolve via Devil's Advocate, R8 (added 2026-06-10) — Armed graph routes ALL project work through the graph, R9 (added 2026-06-10) — Canonical 3-tier hierarchy: Project → Topic → Task, Requirements (+1 more)
 
 ### Community 920 - "Community 920"
-Cohesion: 0.04
-Nodes (47): _PromptModal, Generic one-line input modal. Dismisses with the stripped value or None.      di, Generic one-line input modal. Dismisses with the stripped value or None.      di, Generic one-line input modal. Dismisses with the stripped value or None.      di, s — switch active thread by label., s — switch active thread by label., a — ack all open action items on a thread by label., a — ack all open action items on a thread by label (Z = orphaned/null-thread). (+39 more)
+Cohesion: 0.03
+Nodes (51): _PromptModal, Generic one-line input modal. Dismisses with the stripped value or None.      di, Generic one-line input modal. Dismisses with the stripped value or None.      di, Generic one-line input modal. Dismisses with the stripped value or None.      di, s — switch active thread by label., s — switch active thread by label., a — ack all open action items on a thread by label., a — ack all open action items on a thread by label (Z = orphaned/null-thread). (+43 more)
 
 ### Community 921 - "Community 921"
 Cohesion: 0.13
@@ -2452,11 +2466,11 @@ Nodes (18): bootstrap_tmpfs(), Path, juggle_db_bootstrap — copy durable DB →
 
 ### Community 926 - "Community 926"
 Cohesion: 0.15
-Nodes (16): apply_recent_migrations(), Apply incremental schema migrations 20-36 (idempotent)., Apply incremental schema migrations 20-36 (idempotent)., Apply incremental schema migrations 20-36 (idempotent)., Install the Topic Slug Wheel schema. Idempotent and guarded.      - juggle_meta(, Drop summary, memory_context, memory_loaded, last_reflect_msg_count from threads, run_migration_41(), run_migration_slug_wheel() (+8 more)
+Nodes (17): apply_recent_migrations(), dbops.migrations_recent — schema migrations 20-39 + 41.  Owns: the second half o, Apply incremental schema migrations 20-36 (idempotent)., Apply incremental schema migrations 20-36 (idempotent)., Apply incremental schema migrations 20-36 (idempotent)., Install the Topic Slug Wheel schema. Idempotent and guarded.      - juggle_meta(, Drop summary, memory_context, memory_loaded, last_reflect_msg_count from threads, run_migration_41() (+9 more)
 
 ### Community 927 - "Community 927"
-Cohesion: 0.13
-Nodes (21): Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, snapshot(), _make_project_graph(), TDD tests for lazy DAG loading in the cockpit snapshot.  snapshot(db, load_graph (+13 more)
+Cohesion: 0.11
+Nodes (19): Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, Read DB state into a frozen CockpitState. Only function that touches DB.      Op, snapshot(), 2026-06-10 DA m2 pin: a task-bound thread's cockpit glyph state comes     from g, test_snapshot_exposes_graph_by_project() (+11 more)
 
 ### Community 928 - "Community 928"
 Cohesion: 0.22
@@ -2471,16 +2485,16 @@ Cohesion: 0.20
 Nodes (15): AST, FunctionDef, AST, FunctionDef, _find_func(), _load_watchdog_module(), Assert watchdog _poll_once calls reap_stale_agents; CLI/cmd_agents do not., cmd_get_agent must not call reap_stale_agents — watchdog owns periodic reap. (+7 more)
 
 ### Community 931 - "Community 931"
-Cohesion: 0.13
-Nodes (20): _armed_set(), load_graph_dag(), load_graph_dags(), _load_one(), _load_one_legacy_tasks(), _project_name(), Lazy DAG loader for the cockpit graph panel.  Loads the armed project(s) topic g, Load topic-tier DAGs for all armed projects (CSV settings key), in order. (+12 more)
+Cohesion: 0.17
+Nodes (15): _armed_set(), load_graph_dag(), load_graph_dags(), _load_one(), _load_one_legacy_tasks(), _project_name(), Lazy DAG loader for the cockpit graph panel.  Loads the armed project(s) topic g, Load topic-tier DAGs for all armed projects (CSV settings key), in order. (+7 more)
 
 ### Community 932 - "Community 932"
 Cohesion: 0.07
-Nodes (42): arm_project(), disarm_project(), get_armed_project(), get_armed_projects(), juggle_autopilot_state — armed-project SET accessors (multi-project autopilot)., Ordered, deduped armed project ids; [] when disarmed or pre-migration., Persist the set; empty list clears the key (disarmed)., Append ``pid`` to the armed set (idempotent). Returns the new set. (+34 more)
+Nodes (41): arm_project(), disarm_project(), get_armed_project(), get_armed_projects(), juggle_autopilot_state — armed-project SET accessors (multi-project autopilot)., Ordered, deduped armed project ids; [] when disarmed or pre-migration., Persist the set; empty list clears the key (disarmed)., Append ``pid`` to the armed set (idempotent). Returns the new set. (+33 more)
 
 ### Community 933 - "Community 933"
-Cohesion: 0.22
-Nodes (10): build_startup_output(), _get_juggle_version(), juggle_context_startup — topics tree, thread-state badges, startup output.  Owns, Return up to 2 Hindsight snippet lines for a topic. Empty list on any failure., Render the topics tree as a string. Returns 'No topics.' if no visible threads., Render the topics tree as a string. Returns 'No topics.' if no visible threads., Full enriched startup string: topics tree.      Called by cmd_start (when thread, Full enriched startup string: topics tree + per-thread Hindsight recalls.      C (+2 more)
+Cohesion: 0.10
+Nodes (28): Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, Pure resolver: match query against task id, unique id prefix, or _label.      Pr, resolve_task_detail(), Returns None when query matches nothing., Returns None for empty task list., Returns deps list from the matched task's own deps field. (+20 more)
 
 ### Community 935 - "Community 935"
 Cohesion: 0.43
@@ -2495,16 +2509,16 @@ Cohesion: 0.11
 Nodes (26): GraphNode, GraphTask, Build the graph Panel from the snapshot's lazily-loaded DAGs., _badge_segment(), build_multi_graph_panel(), _cell_text(), _flat_selectable(), _graph_section() (+18 more)
 
 ### Community 938 - "Community 938"
-Cohesion: 0.12
-Nodes (15): CockpitApp.BINDINGS must have a binding for action 'task_detail'., The task_detail binding uses key 'T' or 'shift+t'., task_detail binding appears after the 't' (tail_toggle) binding., CockpitApp must have an action_task_detail method., CockpitApp.BINDINGS must have a binding for action 'task_detail'., The task_detail binding uses key 'i' (information mnemonic)., T' must NOT be bound to task_detail (rebind to 'i')., CockpitApp must have an action_task_detail method. (+7 more)
+Cohesion: 0.09
+Nodes (21): _press_label(), Functional tests for cockpit destructive actions: action_close / action_archive, C → valid label → confirm modal → press n → set_thread_status NOT called., x with unknown label → no DB call., x → valid label → confirm → y → archive_thread called., _ConfirmModal is importable from juggle_cockpit., d with out-of-range index → no confirm modal, no DB call., d → valid index → confirm → y → update_agent called with decommission_pending. (+13 more)
 
 ### Community 939 - "Community 939"
-Cohesion: 0.12
-Nodes (23): db(), JuggleDB, Path, Tests for cockpit graph-task visibility (autopilot Phase 4, DA m2).  Project row, REGRESSION PIN (DA round-2 minor 3, 2026-06-10): an armed project whose     task, Companion to the minor-3 pin: grouping used to require >1 project —     a lone a, 2026-06-10 DA m2 pin: a task-bound thread's cockpit glyph state comes     from g, _render_text() (+15 more)
+Cohesion: 0.20
+Nodes (15): db(), JuggleDB, Path, Tests for cockpit graph-task visibility (autopilot Phase 4, DA m2).  Project row, REGRESSION PIN (DA round-2 minor 3, 2026-06-10): an armed project whose     task, Companion to the minor-3 pin: grouping used to require >1 project —     a lone a, _render_text(), test_armed_project_header_visible_with_zero_visible_topics() (+7 more)
 
 ### Community 941 - "Community 941"
-Cohesion: 0.27
-Nodes (12): _build_old_schema_db(), _cols(), Connection, Migration 39 — rename graph primitive node -> task (T-rename-node-to-task).  REG, REGRESSION PIN (2026-06-13): init_db CREATEs an empty graph_tasks BEFORE     mig, Create a DB with the PRE-rename graph schema and a little data., _tables(), test_fresh_db_has_graph_tasks_not_graph_nodes() (+4 more)
+Cohesion: 0.23
+Nodes (15): apply_graph_migrations(), Apply migrations 35-37 + 39 (graph_tasks / graph_edges / graph_topics + rename)., Apply migrations 35-37 (graph_nodes / graph_edges / graph_topics)., _build_old_schema_db(), _cols(), Connection, Migration 39 — rename graph primitive node -> task (T-rename-node-to-task).  REG, REGRESSION PIN (2026-06-13): init_db CREATEs an empty graph_tasks BEFORE     mig (+7 more)
 
 ### Community 942 - "Community 942"
 Cohesion: 0.12
@@ -2528,11 +2542,11 @@ Nodes (14): interleave_ready(), juggle_graph_scheduler — fair cross-project di
 
 ### Community 1043 - "Community 1043"
 Cohesion: 0.04
-Nodes (87): BaseException, _cmd_selfheal_reset_diagnosing(), _cmd_selfheal_set_status(), _attribute_tool_errors(), _do_class_b_scan(), Path, juggle_hooks_classb — Class B transcript scan (Stop-hook, Juggle-caused errors)., Called from handle_stop(). Silently skips if no transcript_path. (+79 more)
+Nodes (64): _cmd_selfheal_reset_diagnosing(), _cmd_selfheal_set_status(), _attribute_tool_errors(), _do_class_b_scan(), Path, juggle_hooks_classb — Class B transcript scan (Stop-hook, Juggle-caused errors)., Called from handle_stop(). Silently skips if no transcript_path., Parse transcript JSONL and record tool errors attributed to Juggle.      Verifie (+56 more)
 
 ### Community 1073 - "Community 1073"
 Cohesion: 0.07
-Nodes (39): _deep_merge(), get(), get_nested(), get_settings(), # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive, (+31 more)
+Nodes (41): _deep_merge(), get(), get_nested(), get_settings(), # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive,, # NOTE: the claude.ai Google Workspace connectors (Drive, (+33 more)
 
 ### Community 1121 - "Community 1121"
 Cohesion: 0.24
@@ -2559,24 +2573,24 @@ Cohesion: 0.12
 Nodes (12): Inverse of _slug_from_wheel for a valid two-letter A-Z slug, else None., Inverse of _slug_from_wheel for a valid two-letter A-Z slug, else None., _wheel_index(), Regression tests for thread label accumulation bug (2026-06-15).  Original sympt, T-slug-wheel: close-thread keeps the slug as a permanent handle., T-slug-wheel: archive via set_thread_status keeps the slug., update_thread with status=closed must keep user_label., A closed row holding a slug must not block creation of a new thread     whose wh (+4 more)
 
 ### Community 1128 - "Community 1128"
-Cohesion: 0.15
-Nodes (13): cmd_agent_tools(), cmd_cockpit(), _cmd_list_selfheal(), _deny_matches(), juggle_cmd_misc — Miscellaneous CLI command handlers.  Owns: cmd_cockpit (TUI la, Launch the Juggle Cockpit dashboard (Textual, mouse drag-to-resize).      With -, True if tool_name is covered by a deny entry (exact or `prefix*` wildcard)., True if tool_name is covered by a deny entry (exact or `prefix*` wildcard). (+5 more)
+Cohesion: 0.18
+Nodes (11): cmd_agent_tools(), _cmd_list_selfheal(), _deny_matches(), juggle_cmd_misc — Miscellaneous CLI command handlers.  Owns: cmd_cockpit (TUI la, True if tool_name is covered by a deny entry (exact or `prefix*` wildcard)., True if tool_name is covered by a deny entry (exact or `prefix*` wildcard)., True if tool_name is covered by a deny entry (exact or `prefix*` wildcard)., Report per-agent tool usage to systematically right-size the deny block.      Fo (+3 more)
 
 ### Community 1129 - "Community 1129"
 Cohesion: 0.67
 Nodes (3): Companion to the 2026-06-10 any_fail pin: --json with all-pass results     must, Companion to the 2026-06-10 any_fail pin: --json with all-pass results     must, test_smoke_json_all_pass_exits_zero()
 
 ### Community 1130 - "Community 1130"
-Cohesion: 0.13
-Nodes (8): HarnessAdapter, Launch command: explicit per-harness, else legacy key, else the id., Flag fragment that applies per-role tool restrictions.          Base / template, Return the full shell command string to paste into a fresh pane., Return a one-shot shell command that runs ``prompt_file`` to completion., Base adapter — config-driven command, markers and task decoration.      Subclass, True when per-role tool restriction is delegated to the harness's own         co, Whether the harness runs as a long-lived interactive REPL pane.          Interac
+Cohesion: 0.11
+Nodes (9): HarnessAdapter, Launch command: explicit per-harness, else legacy key, else the id., Flag fragment that applies per-role tool restrictions.          Base / template, Return the full shell command string to paste into a fresh pane., Return a one-shot shell command that runs ``prompt_file`` to completion., Adjust a task prompt before it is pasted into the agent.          Default strate, Base adapter — config-driven command, markers and task decoration.      Subclass, True when per-role tool restriction is delegated to the harness's own         co (+1 more)
 
 ### Community 1131 - "Community 1131"
 Cohesion: 0.12
 Nodes (21): _release_singleton_lock(), acquire_singleton_lock(), _any_alive(), assert_launch_allowed(), find_watchdog_pids(), is_prod_db(), is_sanctioned(), lock_path_for() (+13 more)
 
 ### Community 1132 - "Community 1132"
-Cohesion: 0.18
-Nodes (21): _bind_thread(), _fail_node(), _fail_task(), _load_tree(), Autopilot Phase 3 — failure propagation (design rev 2).  Any task entering faile, Regression pin (2026-06-10): completing a mid-graph task with a failed     integ, The failed-verify exit (DA M3 channel) propagates identically., Regression pin (2026-06-10): blocked-failed tasks are operator     territory — t (+13 more)
+Cohesion: 0.17
+Nodes (23): mark_graph_task(), If the thread is bound to a graph task, record the completion outcome.      Maps, _bind_thread(), _fail_node(), _fail_task(), _load_tree(), Autopilot Phase 3 — failure propagation (design rev 2).  Any task entering faile, Regression pin (2026-06-10): completing a mid-graph task with a failed     integ (+15 more)
 
 ### Community 1133 - "Community 1133"
 Cohesion: 0.15
@@ -2599,8 +2613,8 @@ Cohesion: 0.19
 Nodes (13): _make_db(), Path, Tests for juggle_cmd_db_flush (Task 6)., flush_once copies live DB content to durable path atomically., flush_once leaves durable intact if interrupted (uses tmp+rename)., flush_status returns a dict with last_flush_at and age_s fields., flush_status returns None/null last_flush_at when no flush has occurred., age_s in flush_status is >= 0 after a flush. (+5 more)
 
 ### Community 1138 - "Community 1138"
-Cohesion: 0.20
-Nodes (10): assign_project_background(), _assign_thread_to_project(), Assign a thread and mark the old project dirty if the project changed., Assign a thread and mark the old project dirty if the project changed., Fire-and-forget background project assignment via detached subprocess.      Uses, Thread must be non-daemon so process waits for LLM assignment before exiting., test_assign_project_background_sets_assigned_by_auto(), test_assign_project_background_thread_is_not_daemon() (+2 more)
+Cohesion: 0.33
+Nodes (6): assign_project_background(), Fire-and-forget background project assignment via detached subprocess.      Uses, Thread must be non-daemon so process waits for LLM assignment before exiting., test_assign_project_background_sets_assigned_by_auto(), test_assign_project_background_thread_is_not_daemon(), test_assign_project_background_updates_db()
 
 ### Community 1139 - "Community 1139"
 Cohesion: 0.15
@@ -2611,8 +2625,8 @@ Cohesion: 0.18
 Nodes (10): A. `_record_merged_sha` — no object or ancestry check, A. `_record_merged_sha` — three-step gate, B. `ahead_count == 0` shortcut — `merge-base --is-ancestor` guard, B. `ahead_count == 0` shortcut — no canonical-main guard, Defense-in-depth saved us, Fix, Incident: integrate records phantom merged_sha + strands work, Regression tests (+2 more)
 
 ### Community 1141 - "Community 1141"
-Cohesion: 0.26
-Nodes (10): MouseMove, MouseMove, _make_app(), TDD tests for cockpit resize breakpoint and splitter drag bugs.  Cycles:   1. on, After dragging topics narrow then triggering a resize, topics must remain visibl, topics must stay visible after resize when terminal is wide but topics pane is n, After an extreme left drag, topics width must be ≥ _MIN_TOPICS_PCT% of terminal., test_drag_then_resize_no_pane_collapse() (+2 more)
+Cohesion: 0.09
+Nodes (11): Connection, Return the last-seen notification ID for this Claude session, or None if unseen., Open action items ordered by (priority: high > normal > low), then created_at DE, Return the last-seen notification ID for this Claude session, or None if unseen., Record the last-seen notification ID for this Claude session., Return True if session.active == '1'., Return the session_id of the active orchestrator, or '' if not set., Record (or clear) the orchestrator session ID and timestamp. (+3 more)
 
 ### Community 1142 - "Community 1142"
 Cohesion: 0.24
@@ -2631,8 +2645,8 @@ Cohesion: 0.20
 Nodes (9): Capture (reuse existing ledger choke points), Discoverability (part of DONE), Goal, Problem, Restore CLI — `juggle runs restore`, Schema (Migration 40), Tests, VCS abstraction — `src/vcs.py` (+1 more)
 
 ### Community 1164 - "Community 1164"
-Cohesion: 0.13
-Nodes (15): mark_graph_task(), If the thread is bound to a graph task, record the completion outcome.      Maps, check_topic_completion_gate(), enforce_topic_gate(), fail_graph_topic(), mark_graph_topic(), juggle_cmd_agents_graph_topics — TOPIC completion/failure glue (R9 Task 7).  Ext, Agent death on a TOPIC thread → topic failed-exec + derived-dependent     blocki (+7 more)
+Cohesion: 0.22
+Nodes (9): check_topic_completion_gate(), enforce_topic_gate(), fail_graph_topic(), mark_graph_topic(), juggle_cmd_agents_graph_topics — TOPIC completion/failure glue (R9 Task 7).  Ext, Agent death on a TOPIC thread → topic failed-exec + derived-dependent     blocki, R9/A10 gate: complete-agent on a topic thread refuses while any task is     non-, Print + exit(1) when the topic gate refuses (no side effects yet). (+1 more)
 
 ### Community 1169 - "Community 1169"
 Cohesion: 0.11
@@ -2645,6 +2659,10 @@ Nodes (9): Regression pin: cockpit footer must show ALL usable hotkeys.  Inciden
 ### Community 1171 - "Community 1171"
 Cohesion: 0.20
 Nodes (5): Test-DB isolation guard (2026-06-16 prod-DB pollution incident).  Root cause: DB, Any attempt to open the real prod DB during a test is a loud error., Temp DBs connect normally — the guard only fires on the prod path., test_opening_prod_db_raises(), test_temp_db_connect_is_allowed()
+
+### Community 1172 - "Community 1172"
+Cohesion: 0.20
+Nodes (17): BaseException, _compute_class_a_signature(), _compute_class_b_signature(), _get_db(), _get_pending_selfheal_count(), _is_allowlisted(), _is_stdlib(), _now() (+9 more)
 
 ### Community 1192 - "Community 1192"
 Cohesion: 0.11
@@ -2699,16 +2717,16 @@ Cohesion: 0.05
 Nodes (36): 10. `last_send_task_pane_hash` race on slow paste, 1. Race condition: user sends a new task while watchdog is mid-recovery, 2. False positive cost: re-dispatching an agent that was actually working, 3. Snapshot storage: unbounded growth, 4. Cold-start over-triggering: fixed defaults too short for long coder tasks, 5. Pane ID reuse: tmux may recycle pane IDs, 6. `last_task` not set if agent was dispatched before this version, 7. `complete-agent` modifies `agents.status` before computing `busy_since` duration (+28 more)
 
 ### Community 1269 - "Community 1269"
-Cohesion: 0.18
-Nodes (11): Call LLM to produce {context, why, what, result} for a topic.      llm_fn(prompt, Call LLM to produce {{context, why, what, result}} for a topic.      llm_fn(prom, summarize_topic(), After fix, _apply_summary must take the summary branch (not raw fallback)     wh, test_apply_summary_takes_summary_branch_for_markdown(), summarize_topic calls the injected llm_fn and returns parsed sections., summarize_topic returns empty-string dict when llm_fn raises., summarize_topic handles llm_fn returning None gracefully. (+3 more)
+Cohesion: 0.14
+Nodes (13): Blocking worker: call LLM, update body via call_from_thread., Blocking worker: call LLM, update body via call_from_thread., Call LLM to produce {context, why, what, result} for a topic.      llm_fn(prompt, Call LLM to produce {{context, why, what, result}} for a topic.      llm_fn(prom, summarize_topic(), After fix, _apply_summary must take the summary branch (not raw fallback)     wh, test_apply_summary_takes_summary_branch_for_markdown(), summarize_topic calls the injected llm_fn and returns parsed sections. (+5 more)
 
 ### Community 1274 - "Community 1274"
-Cohesion: 0.22
-Nodes (10): cmd_fail_agent(), juggle_cmd_agents_complete — Agent completion and failure handlers.  Owns: cmd_c, Route agent failure: transient → leave running for retry; persistent → action_it, Route agent failure: transient → leave running for retry; persistent → action_it, Route agent failure: transient → leave running for retry; persistent → action_it, Route agent failure: transient → leave running for retry; persistent → action_it, Route agent failure: transient → leave running for retry; persistent → action_it, _make_db() (+2 more)
+Cohesion: 0.16
+Nodes (15): _main_repo_root(), _Path, The MAIN worktree root, even when this module is imported from a linked     work, The MAIN worktree root, even when this module is imported from a linked     work, Return the session-scoped watchdog pidfile path.      If CLAUDE_CODE_SESSION_ID, Return the session-scoped watchdog pidfile path.      If CLAUDE_CODE_SESSION_ID, Return the session-scoped watchdog pidfile path.      If CLAUDE_CODE_SESSION_ID, Start the watchdog for this session, kill-then-restart if one is already running (+7 more)
 
 ### Community 1282 - "Community 1282"
-Cohesion: 0.15
-Nodes (9): Launch the configured agent harness in a pane.          Command construction is, Launch the configured agent harness in a pane.          Command construction is, Spawn a new claude pane, register in DB, return agent dict.          db must be, Spawn a new claude pane, register in DB, return agent dict.          db must be, Spawn a new claude pane, register in DB, return agent dict.          db must be, Create the juggle tmux session + window 0 if not already running., Create the juggle tmux session + window 0 if not already running., Create a new window for the agent. Returns pane_id like '%5'.          Uses new- (+1 more)
+Cohesion: 0.12
+Nodes (14): RuntimeError, Launch the configured agent harness in a pane.          Command construction is, Launch the configured agent harness in a pane.          Command construction is, Spawn a new claude pane, register in DB, return agent dict.          db must be, Spawn a new claude pane, register in DB, return agent dict.          db must be, Spawn a new claude pane, register in DB, return agent dict.          db must be, Create the juggle tmux session + window 0 if not already running., Create the juggle tmux session + window 0 if not already running. (+6 more)
 
 ### Community 1290 - "Community 1290"
 Cohesion: 0.13
@@ -2756,19 +2774,19 @@ Nodes (29): 10. Offline / SessionStart Surfacing, 11. Devil's Advocate, 12. Test
 
 ### Community 1392 - "Community 1392"
 Cohesion: 0.07
-Nodes (54): Any, _agent_is_non_interactive(), _collect_mtimes(), _config_dir(), _poll_once(), _get_agent_age_secs(), get_session_id(), _get_thread_label() (+46 more)
+Nodes (53): Any, _agent_is_non_interactive(), _collect_mtimes(), _config_dir(), _poll_once(), _get_agent_age_secs(), get_session_id(), _get_thread_label() (+45 more)
 
 ### Community 1393 - "Community 1393"
 Cohesion: 0.39
 Nodes (3): apply_quarantine(), Prepend --deselect <path> flags for each quarantined test.      Flags are insert, TestApplyQuarantine
 
 ### Community 1394 - "Community 1394"
-Cohesion: 0.13
-Nodes (26): Reconcile stale busy one-shot agents: dead PID → idle + failure action item., Reconcile stale busy one-shot agents: dead PID → idle + failure action item., Reconcile stale busy one-shot agents: dead PID → idle + failure action item., reconcile_oneshot_agents(), db(), Tests for one-shot agent observability: harness tagging, PID liveness, reconcile, Running init_db twice is safe — Migration 32 must be idempotent., Spawn under current harness, then verify harness persists on re-read. (+18 more)
+Cohesion: 0.14
+Nodes (25): db(), Tests for one-shot agent observability: harness tagging, PID liveness, reconcile, Running init_db twice is safe — Migration 32 must be idempotent., Spawn under current harness, then verify harness persists on re-read., test_busy_agent_age_from_busy_since(), test_cockpit_agent_has_harness_and_model(), test_cockpit_agent_no_harness_is_none(), test_cockpit_snapshot_includes_harness_model_and_busy_age() (+17 more)
 
 ### Community 1395 - "Community 1395"
 Cohesion: 0.17
-Nodes (12): Run juggle_cli.py with a test DB path, override DB_PATH via env., Prints 'No archive candidates.' when nothing qualifies., Prints 'No archive candidates.' when nothing qualifies., show-topics does not display threads with show_in_list=0., show-topics does not display threads with show_in_list=0., run_cli(), test_get_archive_candidates_none(), test_get_messages_plain() (+4 more)
+Nodes (12): Run juggle_cli.py with a test DB path, override DB_PATH via env., unarchive-thread restores thread and prints 'Thread X unarchived., unarchive-thread restores thread and prints 'Thread X unarchived., show-topics does not display threads with show_in_list=0., show-topics does not display threads with show_in_list=0., run_cli(), test_get_messages_plain(), test_get_stale_threads_empty() (+4 more)
 
 ### Community 1396 - "Community 1396"
 Cohesion: 0.14
@@ -2795,20 +2813,20 @@ Cohesion: 0.08
 Nodes (24): 1. Pattern brittleness (recoverable prompt), 2. Stuck-at-prompt mock fidelity, 3. Recovery side effects, 4. Race conditions, 5. DB state pollution, 6. Stall threshold sensitivity, `conftest.py` — Fixtures, `crashed.sh` (+16 more)
 
 ### Community 1402 - "Community 1402"
-Cohesion: 0.23
-Nodes (8): create_topic(), set_topic_thread(), check_task_guard(), check_task_guard refuses send-task for a real topic in tick-owned state., check_task_guard bypasses (returns None) for is_mirror=1 topics.          Regres, Manual send-task to a NON-mirror topic is still allowed even when         the pr, Existing graph_topics rows default to is_mirror=0., TestGuardBypassForMirror
+Cohesion: 0.14
+Nodes (15): graph_tick(), One dispatcher tick for the armed project. Never raises.      Per ready node: at, One dispatcher tick across ALL armed projects, claiming TOPICS (R9).      Per pr, One dispatcher tick for the armed project. Never raises.      Per ready node: at, One dispatcher tick for the armed project. Never raises.      Per ready node: at, One dispatcher tick for the armed project. Never raises.      Per ready node: at, One dispatcher tick for the armed project. Never raises.      Per ready node: at, claim_topic() (+7 more)
 
 ### Community 1403 - "Community 1403"
 Cohesion: 0.43
 Nodes (6): Tests for the vault-path / vault-name CLI commands.  These wrap _get_vault_root(, test_cmd_vault_name_prints_name(), test_cmd_vault_path_prints_root(), test_vault_name_prefers_explicit_then_falls_back(), test_vault_root_handles_leading_slash(), test_vault_root_handles_tilde_prefix()
 
 ### Community 1404 - "Community 1404"
-Cohesion: 0.07
-Nodes (53): get_db(), Return a JuggleDB handle.      db_path: optional override. When omitted, falls b, Resolve user-label or hex-prefix/full UUID to thread UUID.      Accepts:       -, Resolve user-label or hex-prefix/full UUID to thread UUID.      Accepts:       -, _resolve_thread(), cmd_recall_if_cold(), Recall only if thread hasn't loaded memory yet., Restart watchdog + talkback after a ff-merge of juggle's own repo.      Also kil (+45 more)
+Cohesion: 0.13
+Nodes (31): get_db(), Return a JuggleDB handle.      db_path: optional override. When omitted, falls b, Resolve user-label or hex-prefix/full UUID to thread UUID.      Accepts:       -, Resolve user-label or hex-prefix/full UUID to thread UUID.      Accepts:       -, _resolve_thread(), cmd_recall_if_cold(), Recall only if thread hasn't loaded memory yet., _cleanup_orphaned_threads() (+23 more)
 
 ### Community 1405 - "Community 1405"
-Cohesion: 0.12
-Nodes (27): _build(), build_context_string(), build_startup_output(), _current_session_id(), _get_juggle_version(), _graph_node_tag(), _graph_task_tag(), _minute_ts() (+19 more)
+Cohesion: 0.09
+Nodes (35): _build(), build_context_string(), build_startup_output(), _current_session_id(), _get_juggle_version(), _graph_node_tag(), _graph_task_tag(), _minute_ts() (+27 more)
 
 ### Community 1406 - "Community 1406"
 Cohesion: 0.40
@@ -2823,8 +2841,8 @@ Cohesion: 0.40
 Nodes (4): Fix (v1.66.2), Incident: Watchdog G2 crash-loop (2026-06-13), Root cause, Symptom
 
 ### Community 1409 - "Community 1409"
-Cohesion: 0.19
-Nodes (14): _arm_many(), _mk_topic(), REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): the tick dispatched     BEFORE, REGRESSION PIN (2026-06-10): the tick served get_armed_project() only —     a se, REGRESSION PIN (2026-06-10 spec DA): cross-project thread mis-binding     would, REGRESSION PIN (2026-06-10): old mid-batch guard stopped EVERYTHING on     disar, REGRESSION PIN (R4): a ready-scan exception used to abort the whole     tick; bl, Capacity is GLOBAL (MAX_THREADS bounds TOPICS — R9 budget model): a cap     hit (+6 more)
+Cohesion: 0.23
+Nodes (12): _arm_many(), _mk_topic(), REGRESSION PIN (2026-06-10): the tick served get_armed_project() only —     a se, REGRESSION PIN (2026-06-10 spec DA): cross-project thread mis-binding     would, REGRESSION PIN (2026-06-10): old mid-batch guard stopped EVERYTHING on     disar, REGRESSION PIN (R4): a ready-scan exception used to abort the whole     tick; bl, Capacity is GLOBAL (MAX_THREADS bounds TOPICS — R9 budget model): a cap     hit, test_disarm_one_mid_batch_other_project_keeps_dispatching() (+4 more)
 
 ### Community 1410 - "Community 1410"
 Cohesion: 0.16
@@ -2832,7 +2850,7 @@ Nodes (15): _extract_decision_prompt(), Return a concise actionable prompt for a
 
 ### Community 1411 - "Community 1411"
 Cohesion: 0.18
-Nodes (22): test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script (+14 more)
+Nodes (23): test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script, test_graphify_hooks.sh script (+15 more)
 
 ### Community 1412 - "Community 1412"
 Cohesion: 0.09
@@ -2847,12 +2865,12 @@ Cohesion: 0.30
 Nodes (20): get_adapter(), Resolve the harness adapter for ``role``.      Selection precedence: ``agent.har, _cfg(), test_codex_audit_relaxes_sandbox(), test_codex_empty_model_falls_back_to_agent_model(), test_codex_extra_flags_appended(), test_codex_extra_restriction_flag_appended(), test_codex_hook_capable_override_skips_inline() (+12 more)
 
 ### Community 1416 - "Community 1416"
-Cohesion: 0.17
-Nodes (11): Cockpit bell-on-new-blocker tests: bell state attrs + _refresh diff firing rules, First _refresh (prev state empty) does NOT call self.bell()., CockpitApp.__init__ initialises _prev_action_ids and _prev_agent_statuses., CockpitApp.__init__ initialises _bell_enabled., New tier-0 action on 2nd _refresh fires self.bell(); 1st tick does not., Agent transitioning busy→stale on 2nd _refresh fires self.bell()., test_bell_enabled_attr_exists(), test_bell_fires_on_agent_failure() (+3 more)
+Cohesion: 0.19
+Nodes (15): _make_project_graph(), TDD tests for lazy DAG loading in the cockpit snapshot.  snapshot(db, load_graph, P1: topics A (2 tasks, 1 verified) and B with a task edge B→A.        P2: topic, REGRESSION PIN (2026-06-11 R5/R9): the loader rendered TASKS as DAG     tasks an, Default: graph_dag is None and no DAG query runs., Spy: the graph_tasks-by-project DAG query must not fire when flag off., _seed_two_project_topics(), test_dag_loaded_for_armed_project_when_flag_on() (+7 more)
 
 ### Community 1417 - "Community 1417"
 Cohesion: 0.09
-Nodes (34): RuntimeError, _clear_cold_start_failures(), Record a cold-start failure for thread_id.      Returns one of:       'skip', Clear cascade state after successful recovery for thread_id., Clear cascade state after successful recovery for thread_id., Record a cold-start failure for thread_id.      Returns one of:       'skip', Clear cascade state after successful recovery for thread_id., Record a cold-start failure for thread_id.      Returns one of:       'skip' (+26 more)
+Nodes (33): _clear_cold_start_failures(), Record a cold-start failure for thread_id.      Returns one of:       'skip', Clear cascade state after successful recovery for thread_id., Clear cascade state after successful recovery for thread_id., Record a cold-start failure for thread_id.      Returns one of:       'skip', Clear cascade state after successful recovery for thread_id., Record a cold-start failure for thread_id.      Returns one of:       'skip', _record_cold_start_failure() (+25 more)
 
 ### Community 1418 - "Community 1418"
 Cohesion: 0.10
@@ -2864,7 +2882,7 @@ Nodes (9): _DummyCapture, _make_key(), Regression tests for unguarded self.dismi
 
 ### Community 1420 - "Community 1420"
 Cohesion: 0.08
-Nodes (32): cmd_ack_action(), cmd_check_agents(), cmd_decommission_agent(), cmd_list_actions(), cmd_list_agents(), cmd_notify(), cmd_release_agent(), cmd_request_action() (+24 more)
+Nodes (31): cmd_ack_action(), cmd_check_agents(), cmd_decommission_agent(), cmd_list_actions(), cmd_notify(), cmd_release_agent(), cmd_request_action(), cmd_send_message() (+23 more)
 
 ### Community 1421 - "Community 1421"
 Cohesion: 0.19
@@ -2879,8 +2897,8 @@ Cohesion: 0.11
 Nodes (18): Auto-Assignment (Async, Fail-Silent), CLI Commands, Cockpit Changes, Data Model, Failure contract, Flow, Implementation, INBOX project (seeded at migration time) (+10 more)
 
 ### Community 1424 - "Community 1424"
-Cohesion: 0.07
-Nodes (25): CompletedProcess, CompletedProcess, Return True if pane_id exists in the juggle session., Return True if pane_id exists in the juggle session., Return True if pane_id exists in the juggle session., Capture current pane content; return raw text or None on failure.          Used, Capture current pane content; return raw text or None on failure.          Used, Capture current pane content; return raw text or None on failure.          Used (+17 more)
+Cohesion: 0.08
+Nodes (19): CompletedProcess, CompletedProcess, Return True if pane_id exists in the juggle session., Return True if pane_id exists in the juggle session., Return True if pane_id exists in the juggle session., Capture current pane content; return raw text or None on failure.          Used, Capture current pane content; return raw text or None on failure.          Used, Capture current pane content; return raw text or None on failure.          Used (+11 more)
 
 ### Community 1425 - "Community 1425"
 Cohesion: 0.17
@@ -2891,16 +2909,16 @@ Cohesion: 0.12
 Nodes (16): Category 3: Major Project (Superpowers Workflow), CLI Reference, Cockpit, Coder Agent Prompt, Dispatch Protocols, Examples, /juggle:start, Limits (+8 more)
 
 ### Community 1427 - "Community 1427"
-Cohesion: 0.28
-Nodes (8): _make_db(), JuggleDB, Path, Regression pin: cmd_send_task must honor db_path injection (2026-06-11).  Sympto, cmd_send_task with db_path finds agent in the non-default temp DB.      Incident, _dispatch_via_pool includes db_path in the Namespace for cmd_send_task.      Inc, test_cmd_send_task_uses_injected_db_path(), test_dispatch_via_pool_passes_db_path_to_send_task()
+Cohesion: 0.13
+Nodes (16): cmd_send_message(), cmd_send_task(), juggle_cmd_agents_tasks — Task dispatch to pooled agents.  Owns: cmd_send_task (, Auto-create worktree uses agent.repo_path, not os.getcwd()., test_send_task_auto_create_uses_agent_repo_not_cwd(), REGRESSION PIN (DA B5, 2026-06-10): the autopilot LLM loop raced the     tick by, test_send_task_refuses_node_bound_thread_without_force(), test_send_task_refuses_task_bound_thread_without_force() (+8 more)
 
 ### Community 1428 - "Community 1428"
 Cohesion: 0.33
 Nodes (10): fts_search_kb(), get_embedding(), haiku_filter(), _load_env(), main(), _open_kb(), Namespace, Keyword-only KB search — no embeddings provider required. (+2 more)
 
 ### Community 1429 - "Community 1429"
-Cohesion: 0.06
-Nodes (46): build_diagnosis_prompt(), get_diagnosis_candidates(), _in_flight_exists(), maybe_dispatch_selfheal_diagnosis(), purge_expired_selfheal(), datetime, Return open class-A error rows with count >= min_count, ordered count DESC., Pure gate: return the top candidate row or None.      Returns None when disabled (+38 more)
+Cohesion: 0.17
+Nodes (15): purge_expired_selfheal(), Pure gate: return the top candidate row or None.      Returns None when disabled, Delete error_events rows whose last_seen is older than retention_days.      Retu, select_diagnosis_candidate(), Regression-pin tests for selfheal auto-diagnosis loop.  2026-06-17: _try_claim_d, Rows with last_seen older than retention_days are deleted.      2026-06-17: rete, test_purge_expired_deletes_old_rows(), test_purge_expired_keeps_recent_rows() (+7 more)
 
 ### Community 1430 - "Community 1430"
 Cohesion: 0.12
@@ -2959,16 +2977,16 @@ Cohesion: 0.17
 Nodes (11): Cross-links, Juggle Weekly Digest — 2026-05-25, RF-1 Watchdog Health, RF-2 Action Item Fatigue, RF-3 Agent Output Quality, RF-4 Context Bloat Candidates, RF-5 Memory Health, RF-6 Auto-Memory Contradictions (+3 more)
 
 ### Community 1447 - "Community 1447"
-Cohesion: 0.17
-Nodes (20): smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script (+12 more)
+Cohesion: 0.16
+Nodes (21): smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script, smoke_test_agent_compliance.sh script (+13 more)
 
 ### Community 1448 - "Community 1448"
 Cohesion: 0.17
 Nodes (11): Architecture, CLI, Cockpit Viewport Smoke Harness, Frame Dumps, Layout Heuristics, Problem, PTY Driver (`src/juggle_smoke.py`), Solution (+3 more)
 
 ### Community 1450 - "Community 1450"
-Cohesion: 0.12
-Nodes (24): _cheap_llm_call(), _existing_thread_titles(), _humanize_dt(), llm_call(), Return a human-friendly relative time string for an ISO-8601 UTC timestamp., Shim: delegates to llm_call(profile='cheap'). Kept for call-site compat., Shim: delegates to llm_call(profile='cheap'). Kept for call-site compat., Non-empty titles of all OTHER threads, for dedup-awareness. Fail-soft. (+16 more)
+Cohesion: 0.10
+Nodes (28): _cheap_llm_call(), _dedupe_title(), _existing_thread_titles(), llm_call(), Shim: delegates to llm_call(profile='cheap'). Kept for call-site compat., Shim: delegates to llm_call(profile='cheap'). Kept for call-site compat., Lowercase alphanumeric tokens of a title with generic filler removed., True when two titles share the same set of content words.      Catches 'Improve (+20 more)
 
 ### Community 1452 - "Community 1452"
 Cohesion: 0.18
@@ -2983,8 +3001,8 @@ Cohesion: 0.18
 Nodes (11): 8.10 Confirmation bias loop — dogfood reading its own history, 8.1 Routine failure cascade — silent dead routines, 8.2 Bad auto-fix merges silently, 8.3 Issue spam with weak dedup, 8.4 Cross-repo bleed — D2 editing outside juggle, 8.5 Routines feature maturity — April 2026 = ~1 month old, 8.6 Dogfood cost ramp — $14/year for a single analysis section, 8.7 Schedule collision with manual work (+3 more)
 
 ### Community 1455 - "Community 1455"
-Cohesion: 0.35
-Nodes (11): _auto_archive_closed_threads(), _auto_archive_closed_threads(), Archive any closed thread whose last_active_at exceeds the TTL.      Returns cou, Archive any closed thread whose last_active_at exceeds the TTL.      Returns cou, db(), Tests for Task 7 auto-archive hook., _set_last_active(), test_fresh_closed_thread_stays_closed() (+3 more)
+Cohesion: 0.15
+Nodes (21): _auto_archive_closed_threads(), _auto_archive_closed_threads(), build_startup_output(), _get_juggle_version(), juggle_context_startup — topics tree, thread-state badges, startup output.  Owns, Return up to 2 Hindsight snippet lines for a topic. Empty list on any failure., Render the topics tree as a string. Returns 'No topics.' if no visible threads., Render the topics tree as a string. Returns 'No topics.' if no visible threads. (+13 more)
 
 ### Community 1457 - "Community 1457"
 Cohesion: 0.18
@@ -3087,8 +3105,8 @@ Cohesion: 0.29
 Nodes (7): 7.1 Claude Code Routines API — exact interface, 7.2 `juggle.db` access from cloud Routines, 7.3 GitHub auth — App vs PAT, 7.4 Routines cost billing, 7.5 Watchdog snapshot path for F1/FX-4, 7.6 Claude Code session JSONL format for B3/IS-2, 7. Open Questions
 
 ### Community 1493 - "Community 1493"
-Cohesion: 0.33
-Nodes (6): Parse last_active ISO timestamp, return seconds since now, or None., Parse last_active ISO timestamp, return seconds since now, or None., Parse last_active ISO timestamp, return seconds since now, or None., Parse last_active ISO timestamp, return seconds since now, or None., Parse last_active ISO timestamp, return seconds since now, or None., _thread_age_seconds()
+Cohesion: 0.15
+Nodes (7): CockpitHandle, Drain master fd for `settle` seconds, stopping early when quiet., Capture a stable rendered frame as list[str] (one str per row).          Polls u, Change the pty window size mid-session and send SIGWINCH., Send q, wait for clean exit, kill if timeout., PTY-backed interactive handle to a running cockpit process.      Open via open_c, Write key bytes to the pty master fd (real terminal input path).
 
 ### Community 1494 - "Community 1494"
 Cohesion: 0.33
@@ -3119,8 +3137,8 @@ Cohesion: 0.24
 Nodes (9): configure_db_mode(), Write db.mode to config.json idempotently.      Used by juggle:init to persist t, Tests for db-mode init integration (Task 8)., configure_db_mode writes db.mode to config.json idempotently., configure_db_mode can be called twice without error., configure_db_mode preserves other keys in config.json., test_configure_db_mode_idempotent(), test_configure_db_mode_preserves_existing_keys() (+1 more)
 
 ### Community 1501 - "Community 1501"
-Cohesion: 0.14
-Nodes (14): GraphTask, db(), _now(), JuggleDB, Path, Tests for the graph-mirrors-threads feature (Option 1, 2026-06-14).  All tests u, topic_ready_eligible does not return is_mirror=1 topics.          Regression pin, topic_counts counts only is_mirror=0 topics.          Regression pin for 2026-06 (+6 more)
+Cohesion: 0.12
+Nodes (16): create_topic(), GraphTask, db(), _now(), JuggleDB, Path, Tests for the graph-mirrors-threads feature (Option 1, 2026-06-14).  All tests u, topic_ready_eligible does not return is_mirror=1 topics.          Regression pin (+8 more)
 
 ### Community 1502 - "Community 1502"
 Cohesion: 0.40
@@ -3143,8 +3161,8 @@ Cohesion: 0.40
 Nodes (5): 9. Acceptance Criteria, Autofix (Routine 1), Dogfood (Routine 3), Reflect (Routine 2), Shared
 
 ### Community 1507 - "Community 1507"
-Cohesion: 0.33
-Nodes (6): group_threads_by_project(), Return [(project_id, project_name, topics)] sorted: named projects first, INBOX, Return [(project_id, project_name, topics)] sorted: named projects first, INBOX, Return [(project_id, project_name, topics)] sorted: named projects first, INBOX, Return [(project_id, project_name, topics)] sorted: named projects first, INBOX, Return [(project_id, project_name, topics)] sorted: named projects first, INBOX
+Cohesion: 0.14
+Nodes (12): _harness_markers(), Poll capture-pane until a Claude UI readiness marker appears.          Backoff:, Poll capture-pane until a Claude UI readiness marker appears.          Backoff:, Poll capture-pane until a Claude UI readiness marker appears.          Backoff:, Verify a pasted prompt was submitted; retry Enter if stuck.          Success: a, Verify a pasted prompt was submitted; retry Enter if stuck.          Success: a, Verify a pasted prompt was submitted; retry Enter if stuck.          Success: a, Return ``(readiness, submission)`` marker tuples for the default harness.      R (+4 more)
 
 ### Community 1508 - "Community 1508"
 Cohesion: 0.20
@@ -3175,20 +3193,20 @@ Cohesion: 0.27
 Nodes (9): _check_tmpfs_writable(), Tests for split-brain guard (Task 7).  If db.mode=tmpfs and tmpfs_dir is missing, JuggleDB raises if mode=tmpfs and tmpfs_dir does not exist., JuggleDB raises if mode=tmpfs and tmpfs_dir is not writable., _check_tmpfs_writable does not raise for a writable dir., Import and call the guard function., test_splitbrain_guard_passes_for_writable_dir(), test_splitbrain_guard_raises_when_tmpfs_dir_missing() (+1 more)
 
 ### Community 1518 - "Community 1518"
-Cohesion: 0.14
-Nodes (13): LANG, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script (+5 more)
+Cohesion: 0.13
+Nodes (14): LANG, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script, stuck-at-prompt.sh script (+6 more)
 
 ### Community 1519 - "Community 1519"
-Cohesion: 0.40
-Nodes (3): cmd_list_agents(), cmd_spawn_agent(), juggle_cmd_agents_pool — Agent pool spawn/list/status commands.  Owns: cmd_spawn
+Cohesion: 0.15
+Nodes (13): CapacityError, _dispatch_via_pool(), get_armed_project(), Dispatch ``prompt`` for ``thread_id`` through the existing CLI path:     cmd_get, Dispatch ``prompt`` for ``thread_id`` through the existing CLI path:     cmd_get, Dispatch ``prompt`` for ``thread_id`` through the existing CLI path:     cmd_get, Thread/agent capacity hit — defer quietly and retry next tick., Armed project id from the settings table, or None when disarmed. (+5 more)
 
 ### Community 1520 - "Community 1520"
 Cohesion: 0.20
 Nodes (10): _last_sentences(), Return the tail of text, capped at max_chars., Return the tail of text, capped at max_chars., _last_sentences returns up to max_chars of stripped text., Text longer than max_chars is truncated., _last_sentences returns up to max_chars of stripped text., Text longer than max_chars is truncated., test_last_sentences_basic_truncation() (+2 more)
 
 ### Community 1521 - "Community 1521"
-Cohesion: 0.20
-Nodes (9): Return the AGENT ROLE anchor block for an explicit ``role``.      Shared by the, Return the AGENT ROLE anchor block for an explicit ``role``.      Shared by the, Return the AGENT ROLE anchor block for an explicit ``role``.      Shared by the, Return the AGENT ROLE anchor block for agent panes. Empty string otherwise., Return the AGENT ROLE anchor block for agent panes. Empty string otherwise., Return the AGENT ROLE anchor block for agent panes. Empty string otherwise., _render_agent_role_anchor(), render_agent_role_anchor_for() (+1 more)
+Cohesion: 0.17
+Nodes (12): _in_flight_exists(), maybe_dispatch_selfheal_diagnosis(), Claim a diagnosis slot and dispatch a coder agent if conditions are met.      Re, Given enabled + qualifying row, dispatch_fn is called with right prompt., If a row is already 'diagnosing', no new dispatch occurs., After dispatch, the claimed row status should be 'awaiting_approval'., JUGGLE_SELFHEAL_OP must be set when dispatch_fn is called., test_maybe_dispatch_dispatches_when_enabled() (+4 more)
 
 ### Community 1522 - "Community 1522"
 Cohesion: 0.33
@@ -3199,8 +3217,8 @@ Cohesion: 0.25
 Nodes (7): Tests for JuggleDB tmpfs bootstrap wiring (Task 5)., JuggleDB in direct mode behaves exactly as before — no tmpfs logic., JuggleDB with mode=tmpfs connects to the live (tmpfs) path, not durable., JuggleDB tmpfs mode bootstraps live from durable when live is absent., test_juggldb_direct_mode_unchanged(), test_juggledb_tmpfs_creates_live_from_durable(), test_juggledb_tmpfs_mode_uses_live_path()
 
 ### Community 1524 - "Community 1524"
-Cohesion: 0.33
-Nodes (7): cmd_project_assign(), _make_args(), test_cmd_project_assign_archived_thread(), test_cmd_project_assign_bulk(), test_cmd_project_assign_logs_correction_when_project_changes(), test_cmd_project_assign_no_correction_when_same_project(), test_cmd_project_assign_sets_assigned_by_human()
+Cohesion: 0.22
+Nodes (10): _assign_thread_to_project(), cmd_project_assign(), Assign a thread and mark the old project dirty if the project changed., Assign a thread and mark the old project dirty if the project changed., _make_args(), test_cmd_project_assign_archived_thread(), test_cmd_project_assign_bulk(), test_cmd_project_assign_logs_correction_when_project_changes() (+2 more)
 
 ### Community 1525 - "Community 1525"
 Cohesion: 0.33
@@ -3211,16 +3229,16 @@ Cohesion: 0.20
 Nodes (7): Cockpit tail drawer / focus-pane tests: action_focus_pane, action_tail_toggle, _, Drawer attrs _tail_active / _tail_pane_id must NOT exist — replaced by _TailModa, f → type 1 → enter → _tmux_focus_pane called with agent's pane_id., t → 1 → enter pushes _TailModal; injected capture_fn calls _tmux_capture_pane., test_action_focus_pane_calls_tmux_with_correct_pane_id(), test_action_tail_toggle_pushes_modal_and_injects_capture(), test_tail_drawer_state_attrs_removed_from_init()
 
 ### Community 1527 - "Community 1527"
-Cohesion: 0.22
-Nodes (8): ? — show help overlay., ? — show help overlay., ? — show help overlay., ? — show help overlay., ? — show help overlay., ? — show help overlay., ? — show help overlay., ? — show help overlay.
+Cohesion: 0.17
+Nodes (11): TDD regression-pin tests for thread dedup scorer (token-set Jaccard + guards)., Numbered-series guard must return exactly 0.0 for sequence variants.      2026-0, THREAD_DEDUP_THRESHOLD must be 2/3 (backtest sweet-spot, exact fraction)., Title generator must not push near-duplicate titles apart.      2026-06-17: _ded, Spec/impl pairs of the SAME feature must score >= THRESHOLD so dedup fires., Distinct-iteration and short-stub pairs must score < THRESHOLD.      2026-06-17:, test_dedup_threshold_is_two_thirds(), test_generate_title_skips_disambiguation_for_near_duplicate() (+3 more)
 
 ### Community 1528 - "Community 1528"
 Cohesion: 0.07
 Nodes (27): Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, Live tail overlay for a tmux pane.      Pops on top of the cockpit when the user, _TailModal (+19 more)
 
 ### Community 1529 - "Community 1529"
-Cohesion: 0.39
-Nodes (7): db(), Tests for Task 2 thread state helpers., test_get_threads_by_status(), test_set_thread_status_closed_sets_last_active_now(), test_set_thread_status_rejects_invalid(), test_set_thread_status_to_running_updates_last_active(), test_touch_last_active_updates_timestamp()
+Cohesion: 0.18
+Nodes (7): Record the last-seen notification ID for this Claude session., Return the last user message and last assistant message for a thread.          R, Return all agents ordered by creation time., Return all non-resolved error_events rows, newest last., Unarchive: status=active, show_in_list=1, user_label preserved., Look up a thread by its UUID `id`. Returns None if not found., Look up a thread by its UUID `id`. Returns None if not found.
 
 ### Community 1530 - "Community 1530"
 Cohesion: 0.24
@@ -3239,24 +3257,24 @@ Cohesion: 0.40
 Nodes (5): _make_modal_instance(), Regression pin (2026-06-17): _TopicDetailModal._fetch_summary called self.call_f, Build a minimal stand-in for _TopicDetailModal with no call_from_thread., _fetch_summary must call self.app.call_from_thread, not self.call_from_thread., test_fetch_summary_uses_app_call_from_thread()
 
 ### Community 1534 - "Community 1534"
-Cohesion: 0.24
-Nodes (9): _age_claim(), _age_topic_claim(), Tests for juggle_graph_dispatch — watchdog-owned dispatcher (autopilot Phase 2)., Crash between claim and send-task (no thread bound): after 10 min the     sweep, REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): simulate a hard crash     after, REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): simulate a hard crash     after, test_crash_in_dispatch_window_not_reclaimed_by_sweep(), test_crash_mid_dispatch_recovers_via_sweep_then_redispatches() (+1 more)
+Cohesion: 0.16
+Nodes (18): _age_claim(), _age_topic_claim(), _mk(), Tests for juggle_graph_dispatch — watchdog-owned dispatcher (autopilot Phase 2)., Crash between claim and send-task (no thread bound): after 10 min the     sweep, (adapted to topics, R9 2026-06-11), (adapted to topics, R9 2026-06-11), REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): the tick dispatched     BEFORE (+10 more)
 
 ### Community 1547 - "Community 1547"
-Cohesion: 0.15
-Nodes (12): crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script (+4 more)
+Cohesion: 0.14
+Nodes (13): crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script, crashed.sh script (+5 more)
 
 ### Community 1548 - "Community 1548"
-Cohesion: 0.15
-Nodes (12): recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script (+4 more)
+Cohesion: 0.14
+Nodes (13): recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script, recoverable-prompt.sh script (+5 more)
 
 ### Community 1549 - "Community 1549"
-Cohesion: 0.15
-Nodes (12): stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script (+4 more)
+Cohesion: 0.14
+Nodes (13): stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script, stalled-silent.sh script (+5 more)
 
 ### Community 1550 - "Community 1550"
-Cohesion: 0.15
-Nodes (12): working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script (+4 more)
+Cohesion: 0.14
+Nodes (13): working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script, working.sh script (+5 more)
 
 ### Community 1551 - "Community 1551"
 Cohesion: 0.22
@@ -3287,56 +3305,60 @@ Cohesion: 0.12
 Nodes (15): Acceptance-criteria scorecard (vs plan), Baseline notes, Before / After, Before / After (FINAL — end of Phase 5, 2026-06-10), Deferrals carried forward (post-refactor follow-ups), Follow-ups (deferred behavior changes), loc_gate allowlist after Phase 2, Phase 3 (2026-06-10, second session) (+7 more)
 
 ### Community 1564 - "Community 1564"
-Cohesion: 0.15
-Nodes (18): _arm(), _mk(), (adapted to topics, R9 2026-06-11), (adapted to topics, R9 2026-06-11), REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): the tick dispatched     BEFORE, Guard for the MAJOR-4 reorder: defer/failure paths must clear the     binding th, Guard for the MAJOR-4 reorder: defer/failure paths must clear the     binding th, One-off dispatch hiccups must not accumulate toward the give-up cap.     (adapte (+10 more)
+Cohesion: 0.24
+Nodes (10): _make_db(), Regression pin: footer must remain visible at narrow (40-col) widths.  All requi, Locks which hints are shown/hidden to prevent uncontrolled footer growth.      I, Footer widget is present and has positive height at 40×20., Switch, Ack, Close, Archive, Help hints all render at 40-col width.      Inciden, Footer content width does not exceed 80 cols (minimum realistic terminal)., test_footer_exists_at_narrow_width(), test_footer_fits_within_40_cols() (+2 more)
 
 ### Community 1565 - "Community 1565"
 Cohesion: 0.33
 Nodes (7): find_cycle(), lint_verify_cmd(), Return an error string if ``cmd`` fails the lint, else None., Return a list of validation error strings (empty = valid)., Kahn's algorithm over (node_id, depends_on_id) pairs. Pure.      Returns the lis, Return a list of validation error strings (empty = valid)., validate_graph()
 
 ### Community 1566 - "Community 1566"
-Cohesion: 0.17
-Nodes (11): install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script (+3 more)
+Cohesion: 0.15
+Nodes (12): install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script, install-graphify-hooks.sh script (+4 more)
 
 ### Community 1567 - "Community 1567"
-Cohesion: 0.40
-Nodes (5): DA M4: dep TOPIC prompts hydrate from dep-TOPIC handoffs only., Walk a ready topic to 'verified' (claim→dispatch→integrate). Binds a     merged, test_hydration_never_uses_thread_summary(), test_hydration_uses_topic_handoff_not_junk(), _verify_topic()
+Cohesion: 0.22
+Nodes (9): _make_current_db(), Path, REGRESSION PIN (2026-06-15): doctor skipped init_db when schema appeared     'cu, Create a minimal DB that looks 'current' to doctor (no stale/node_era markers)., In --dry-run mode, doctor must NOT call init_db; output must indicate     it wou, T-slug-wheel: slugs are PERMANENT historical handles. Doctor must NOT     null u, test_doctor_always_calls_init_db_on_current_schema(), test_doctor_dry_run_skips_init_db() (+1 more)
 
 ### Community 1568 - "Community 1568"
 Cohesion: 0.33
 Nodes (5): Design (RESOLVED — do not redesign), Files to Change, Problem, Selfheal Auto-Diagnosis Loop, Task List
 
 ### Community 1569 - "Community 1569"
-Cohesion: 0.40
-Nodes (5): _TailModal dismisses itself when 'escape' is pressed., _TailModal dismisses itself when 'escape' is pressed., _TailModal dismisses itself when 'escape' is pressed., _TailModal dismisses itself when 'escape' is pressed., test_tail_modal_dismiss_on_escape()
+Cohesion: 0.25
+Nodes (8): _humanize_dt(), Return a human-friendly relative time string for an ISO-8601 UTC timestamp., Return a human-friendly relative time string for an ISO-8601 UTC timestamp., Render a structured context briefing for a thread. Template rendering — no LLM c, Render a structured context briefing for a thread. Template rendering — no LLM c, Render a structured context briefing for a thread. Template rendering — no LLM c, Render a structured context briefing for a thread. Template rendering — no LLM c, _render_briefing()
 
 ### Community 1570 - "Community 1570"
-Cohesion: 0.40
-Nodes (5): --handoff must be wired into the complete-agent parser., --handoff must be wired into the complete-agent parser., --handoff must be wired into the complete-agent parser., --handoff must be wired into the complete-agent parser., test_complete_agent_handoff_cli_flag_registered()
+Cohesion: 0.25
+Nodes (3): _now(), Close a project: hide threads, write summaries, release busy agents. Guards INBO, Close a project: hide threads, write summaries, release busy agents. Guards INBO
 
 ### Community 1571 - "Community 1571"
-Cohesion: 0.15
-Nodes (11): FakeDispatch, (adapted to topics, R9 2026-06-11), (adapted to topics, R9 2026-06-11), REGRESSION PIN (DA round-2 minor 6, 2026-06-10): EVERY ValueError from     creat, REGRESSION PIN (DA round-2 minor 6, 2026-06-10): EVERY ValueError from     creat, Records dispatches; optionally raises. No tmux, no LLM., R6 pin: a 1-element armed set with synthetic 1-task topics behaves like     the, test_single_project_single_topic_behavior_unchanged() (+3 more)
+Cohesion: 0.10
+Nodes (23): _arm(), FakeDispatch, DA M4: dep TOPIC prompts hydrate from dep-TOPIC handoffs only., (adapted to topics, R9 2026-06-11), (adapted to topics, R9 2026-06-11), REGRESSION PIN (DA round-2 MAJOR-4, 2026-06-10): the tick dispatched     BEFORE, Guard for the MAJOR-4 reorder: defer/failure paths must clear the     binding th, Guard for the MAJOR-4 reorder: defer/failure paths must clear the     binding th (+15 more)
 
 ### Community 1572 - "Community 1572"
-Cohesion: 0.40
-Nodes (5): Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., Integration: cockpit renders at 80x67 (2k_third), no overflow, frame dumped., test_render_2k_third_no_overflow_and_frame_file_written()
+Cohesion: 0.43
+Nodes (7): build_topic_hydration(), Dispatch prompt for a TOPIC (R9 hybrid): project objective + dep-topic     hando, Topic hydration (R9): objective + dep-TOPIC handoffs + SEQUENTIAL task list + th, _tasks(), test_topic_hydration_contains_contract_and_order(), test_verified_task_flagged_for_skip(), _topic()
 
 ### Community 1573 - "Community 1573"
 Cohesion: 0.33
-Nodes (6): REGRESSION PIN (2026-06-10): create_thread on db1 must be visible via     get_th, REGRESSION PIN (2026-06-10): create_thread on db1 must be visible via     get_th, REGRESSION PIN (DA round-2 minor 2, 2026-06-10): _dispatch_via_pool     released, REGRESSION PIN (DA round-2 minor 2, 2026-06-10): _dispatch_via_pool     released, test_cross_connection_thread_visibility(), test_dispatch_via_pool_releases_agent_on_any_exception()
+Nodes (6): build_diagnosis_prompt(), Pure prompt builder for a diagnosis coder agent.      Carries all fields the age, Prompt must include sig, exc_type, entrypoint, traceback, count., build_diagnosis_prompt must not raise and must be deterministic., test_build_diagnosis_prompt_contains_key_fields(), test_build_diagnosis_prompt_is_pure()
 
 ### Community 1574 - "Community 1574"
-Cohesion: 0.40
-Nodes (5): Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., Flow: Tab cycles focused pane — grid must differ from initial after 2 tabs., test_flow_tab_cycles_pane_grid_changes()
+Cohesion: 0.33
+Nodes (6): datetime, Reset rows stuck in 'diagnosing' beyond staleness_secs back to 'open'.      Retu, reset_stale_diagnosing_rows(), Rows stuck in 'diagnosing' beyond staleness_secs are reset to 'open'.      2026-, test_reset_stale_diagnosing_rows_leaves_fresh_alone(), test_reset_stale_diagnosing_rows_resets_old_diagnosing()
 
 ### Community 1575 - "Community 1575"
-Cohesion: 0.50
-Nodes (4): check_node_guard(), DA B5: manual send-task to a tick-owned node is a double-dispatch race.      Ret, test_check_node_guard_allows_operator_states_and_unbound(), test_check_node_guard_refuses_tick_owned_states()
+Cohesion: 0.33
+Nodes (6): Atomically claim the diagnosis slot. Returns True if claimed., Atomically claim the diagnosis slot. Returns True if claimed., _try_claim_diagnosis_slot(), Class A: simulate exception → record → claim diagnosis → resolve → regression., Class A: simulate exception → record → claim diagnosis → resolve → regression., test_class_a_e2e_record_and_claim()
 
 ### Community 1576 - "Community 1576"
 Cohesion: 0.40
 Nodes (5): Unit guard: _compute_ratios never returns 0.0 for topics (no PTY needed)., Unit guard: _compute_ratios never returns 0.0 for topics (no PTY needed)., Unit guard: _compute_ratios never returns 0.0 for topics (no PTY needed)., Unit guard: _compute_ratios never returns 0.0 for topics (no PTY needed)., test_compute_ratios_floor_no_pty()
+
+### Community 1577 - "Community 1577"
+Cohesion: 0.40
+Nodes (5): get_diagnosis_candidates(), Return open class-A error rows with count >= min_count, ordered count DESC., Only open class-A rows with count >= min_count are returned., test_get_diagnosis_candidates_ordered_by_count_desc(), test_get_diagnosis_candidates_returns_open_class_a_above_min()
 
 ### Community 1578 - "Community 1578"
 Cohesion: 0.50
@@ -3347,12 +3369,12 @@ Cohesion: 0.29
 Nodes (7): _dep_topic(), (adapted to topics, R9 2026-06-11), REGRESSION PIN (DA round-2 minor 1, 2026-06-10): a permanently broken     dispat, REGRESSION PIN (DA round-2 minor 1, 2026-06-10): a permanently broken     dispat, Make topic `child` derive-depend on `parent`: child's task → parent's., test_dispatch_retry_cap_marks_failed_exec_and_stops_flood(), test_tick_dispatches_ready_tasks_and_binds_threads()
 
 ### Community 1580 - "Community 1580"
-Cohesion: 0.33
-Nodes (6): A completion that crashes between marking 'verified' and topic-ready     recompu, A completion that crashes between marking 'verified' and ready-recompute     wou, MAX_THREADS during lazy create_thread: skip + retry next tick, topic     back to, MAX_THREADS during lazy create_thread: skip + retry next tick, node     back to, test_tick_cap_hit_defers_and_retries_next_tick(), test_tick_self_heals_missed_ready_promotion()
+Cohesion: 0.18
+Nodes (11): _bind_merged_topic(), _merged_repo(), Path, A completion that crashes between marking 'verified' and topic-ready     recompu, A completion that crashes between marking 'verified' and ready-recompute     wou, MAX_THREADS during lazy create_thread: skip + retry next tick, topic     back to, MAX_THREADS during lazy create_thread: skip + retry next tick, node     back to, A real repo whose 'main' branch satisfies the G1 verified⟺merged guard. (+3 more)
 
 ### Community 1581 - "Community 1581"
-Cohesion: 0.67
-Nodes (3): has_busy_agents(), Return True if any agent currently has status='busy'., Return True if any agent currently has status='busy'.
+Cohesion: 0.40
+Nodes (5): Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., Integration: topics pane stays non-zero across 240→120→80→200 resize sequence., test_topics_nonzero_after_multi_resize()
 
 ### Community 1582 - "Community 1582"
 Cohesion: 0.53
@@ -3375,8 +3397,8 @@ Cohesion: 0.67
 Nodes (3): Already-archived threads do not appear in candidate list., Already-archived threads do not appear in candidate list., test_get_archive_candidates_excludes_archived()
 
 ### Community 1588 - "Community 1588"
-Cohesion: 0.67
-Nodes (3): unarchive-thread restores thread and prints 'Thread X unarchived., unarchive-thread restores thread and prints 'Thread X unarchived., test_unarchive_thread_cli()
+Cohesion: 0.50
+Nodes (4): The VERIFY_FAIL_PREFIX channel maps to 'failed-verify' on the node —     distinc, The VERIFY_FAIL_PREFIX channel maps to 'failed-verify' on the task —     distinc, test_verify_failure_marks_node_failed_verify_not_failed_integration(), test_verify_failure_marks_task_failed_verify_not_failed_integration()
 
 ### Community 1589 - "Community 1589"
 Cohesion: 0.67
@@ -3386,20 +3408,56 @@ Nodes (3): unarchive-thread accepts full UUID., unarchive-thread accepts full UU
 Cohesion: 0.67
 Nodes (3): ⏸️ thread shows 🤔 decision prompt instead of Last: Q/A block., ⏸️ thread shows 🤔 decision prompt instead of Last: Q/A block., test_show_topics_waiting_thread_shows_decision_prompt()
 
+### Community 1597 - "Community 1597"
+Cohesion: 0.67
+Nodes (3): Prints 'No archive candidates.' when nothing qualifies., Prints 'No archive candidates.' when nothing qualifies., test_get_archive_candidates_none()
+
+### Community 1598 - "Community 1598"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1599 - "Community 1599"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1600 - "Community 1600"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1601 - "Community 1601"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1602 - "Community 1602"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1603 - "Community 1603"
+Cohesion: 0.67
+Nodes (3): Regression pin (2026-06-10): `cockpit --smoke --viewport X --json` crashed     w, Regression pin (2026-06-10): `cockpit --smoke --viewport X --json` crashed     w, test_smoke_json_single_viewport_exits_cleanly()
+
+### Community 1604 - "Community 1604"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
+### Community 1605 - "Community 1605"
+Cohesion: 0.67
+Nodes (3): db(), JuggleDB, Path
+
 ## Knowledge Gaps
-- **1026 isolated node(s):** `name`, `name`, `plugins`, `name`, `description` (+1021 more)
+- **1031 isolated node(s):** `name`, `name`, `plugins`, `name`, `description` (+1026 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **1144 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **1147 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `JuggleDB` connect `Community 0` to `Community 1`, `Community 4`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 1554`, `Community 1043`, `Community 19`, `Community 21`, `Community 1556`, `Community 23`, `Community 1555`, `Community 25`, `Community 26`, `Community 24`, `Community 29`, `Community 30`, `Community 543`, `Community 32`, `Community 1569`, `Community 1571`, `Community 1572`, `Community 1574`, `Community 39`, `Community 1576`, `Community 41`, `Community 46`, `Community 1582`, `Community 48`, `Community 52`, `Community 566`, `Community 61`, `Community 62`, `Community 1134`, `Community 1137`, `Community 1138`, `Community 1141`, `Community 1169`, `Community 1195`, `Community 707`, `Community 1243`, `Community 227`, `Community 1274`, `Community 795`, `Community 798`, `Community 803`, `Community 805`, `Community 296`, `Community 820`, `Community 821`, `Community 822`, `Community 826`, `Community 828`, `Community 835`, `Community 839`, `Community 840`, `Community 841`, `Community 853`, `Community 854`, `Community 865`, `Community 871`, `Community 877`, `Community 879`, `Community 1394`, `Community 888`, `Community 1402`, `Community 1404`, `Community 893`, `Community 1405`, `Community 895`, `Community 896`, `Community 897`, `Community 898`, `Community 900`, `Community 389`, `Community 902`, `Community 903`, `Community 1417`, `Community 1418`, `Community 1420`, `Community 909`, `Community 911`, `Community 1427`, `Community 916`, `Community 917`, `Community 1429`, `Community 920`, `Community 1433`, `Community 925`, `Community 934`, `Community 939`, `Community 941`, `Community 1455`, `Community 944`, `Community 1475`, `Community 1501`, `Community 1513`, `Community 1524`, `Community 1527`, `Community 1528`, `Community 1529`, `Community 1530`, `Community 1531`?**
-  _High betweenness centrality (0.315) - this node is a cross-community bridge._
-- **Why does `datetime` connect `Community 893` to `Community 0`, `Community 1`, `Community 900`, `Community 778`, `Community 1420`, `Community 12`, `Community 14`, `Community 15`, `Community 1043`, `Community 1172`, `Community 1429`, `Community 150`, `Community 1434`, `Community 32`, `Community 805`, `Community 1450`, `Community 171`, `Community 1582`, `Community 1455`, `Community 50`, `Community 822`, `Community 838`, `Community 844`, `Community 856`, `Community 1242`, `Community 1501`, `Community 1122`, `Community 1519`, `Community 1394`, `Community 243`, `Community 888`, `Community 1274`, `Community 1020`, `Community 1534`?**
-  _High betweenness centrality (0.081) - this node is a cross-community bridge._
-- **Why does `Path` connect `Community 822` to `Community 896`, `Community 0`, `Community 898`, `Community 1282`, `Community 4`, `Community 6`, `Community 11`, `Community 1420`, `Community 12`, `Community 1421`, `Community 1424`, `Community 17`, `Community 1554`, `Community 1043`, `Community 1428`, `Community 1553`, `Community 1431`, `Community 1434`, `Community 1439`, `Community 31`, `Community 801`, `Community 802`, `Community 38`, `Community 42`, `Community 43`, `Community 47`, `Community 1073`, `Community 832`, `Community 839`, `Community 841`, `Community 844`, `Community 855`, `Community 864`, `Community 1134`, `Community 1392`, `Community 880`, `Community 1396`, `Community 1530`, `Community 1403`, `Community 1404`, `Community 1405`, `Community 890`?**
-  _High betweenness centrality (0.070) - this node is a cross-community bridge._
+- **Why does `JuggleDB` connect `Community 0` to `Community 1`, `Community 4`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 1554`, `Community 19`, `Community 1556`, `Community 21`, `Community 1043`, `Community 23`, `Community 1555`, `Community 25`, `Community 24`, `Community 26`, `Community 29`, `Community 30`, `Community 543`, `Community 32`, `Community 1570`, `Community 1571`, `Community 1574`, `Community 39`, `Community 1575`, `Community 41`, `Community 1576`, `Community 1580`, `Community 1581`, `Community 46`, `Community 1582`, `Community 48`, `Community 52`, `Community 566`, `Community 1591`, `Community 1592`, `Community 1593`, `Community 1594`, `Community 1595`, `Community 1596`, `Community 61`, `Community 1598`, `Community 1599`, `Community 1600`, `Community 1601`, `Community 62`, `Community 1602`, `Community 1604`, `Community 1605`, `Community 1134`, `Community 1137`, `Community 1138`, `Community 1141`, `Community 1169`, `Community 1172`, `Community 1195`, `Community 707`, `Community 1243`, `Community 227`, `Community 773`, `Community 795`, `Community 798`, `Community 803`, `Community 805`, `Community 296`, `Community 820`, `Community 821`, `Community 822`, `Community 826`, `Community 835`, `Community 839`, `Community 840`, `Community 841`, `Community 853`, `Community 854`, `Community 865`, `Community 866`, `Community 871`, `Community 877`, `Community 879`, `Community 1394`, `Community 888`, `Community 1404`, `Community 1405`, `Community 893`, `Community 895`, `Community 896`, `Community 897`, `Community 898`, `Community 900`, `Community 389`, `Community 902`, `Community 903`, `Community 1417`, `Community 1418`, `Community 1420`, `Community 911`, `Community 1427`, `Community 916`, `Community 917`, `Community 920`, `Community 1433`, `Community 925`, `Community 934`, `Community 939`, `Community 941`, `Community 1455`, `Community 944`, `Community 1475`, `Community 1501`, `Community 1513`, `Community 1524`, `Community 1528`, `Community 1529`, `Community 1530`, `Community 1531`?**
+  _High betweenness centrality (0.308) - this node is a cross-community bridge._
+- **Why does `Path` connect `Community 822` to `Community 896`, `Community 0`, `Community 898`, `Community 1282`, `Community 4`, `Community 6`, `Community 11`, `Community 1420`, `Community 12`, `Community 1421`, `Community 1424`, `Community 17`, `Community 1554`, `Community 1553`, `Community 1428`, `Community 1172`, `Community 1043`, `Community 1431`, `Community 1434`, `Community 1439`, `Community 31`, `Community 801`, `Community 38`, `Community 42`, `Community 43`, `Community 47`, `Community 1073`, `Community 832`, `Community 839`, `Community 841`, `Community 844`, `Community 855`, `Community 864`, `Community 1507`, `Community 1134`, `Community 1392`, `Community 880`, `Community 1396`, `Community 1530`, `Community 1403`, `Community 1404`, `Community 1405`, `Community 890`?**
+  _High betweenness centrality (0.078) - this node is a cross-community bridge._
+- **Why does `datetime` connect `Community 888` to `Community 0`, `Community 900`, `Community 778`, `Community 1420`, `Community 12`, `Community 14`, `Community 911`, `Community 910`, `Community 15`, `Community 1427`, `Community 916`, `Community 1172`, `Community 1429`, `Community 1434`, `Community 32`, `Community 802`, `Community 805`, `Community 1450`, `Community 171`, `Community 1582`, `Community 1455`, `Community 50`, `Community 822`, `Community 828`, `Community 835`, `Community 707`, `Community 838`, `Community 840`, `Community 844`, `Community 856`, `Community 1242`, `Community 1501`, `Community 1122`, `Community 1394`, `Community 243`, `Community 1402`, `Community 1020`, `Community 893`, `Community 1534`?**
+  _High betweenness centrality (0.068) - this node is a cross-community bridge._
 - **Are the 907 inferred relationships involving `JuggleDB` (e.g. with `BaseException` and `CockpitState`) actually correct?**
   _`JuggleDB` has 907 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 356 inferred relationships involving `JuggleTmuxManager` (e.g. with `JuggleTmuxManager` and `MouseMove`) actually correct?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,676 +1,676 @@
 {
   "tests/test_research_cmd.py": {
-    "mtime": 1781734908.6461236,
+    "mtime": 1781742682.3407664,
     "ast_hash": "144115adc8fd59fc9431838cf9eaa59c",
     "semantic_hash": ""
   },
   "tests/test_juggle_memory_e2e.py": {
-    "mtime": 1781409551.6306844,
+    "mtime": 1781742682.3291087,
     "ast_hash": "7bd57169e24031a03692d6cf4772dbf3",
     "semantic_hash": ""
   },
   "tests/test_juggle_context.py": {
-    "mtime": 1781586013.373625,
+    "mtime": 1781742682.3275878,
     "ast_hash": "b8d10c65d9bc037263b1fcb6e90dde68",
     "semantic_hash": ""
   },
   "tests/test_talkback.py": {
-    "mtime": 1779743365.6357298,
+    "mtime": 1781742682.3448625,
     "ast_hash": "678cd4c0c2237352d5c1cf4b320ae02e",
     "semantic_hash": ""
   },
   "tests/test_juggle_smoke.py": {
-    "mtime": 1781391524.9517345,
+    "mtime": 1781742682.3305714,
     "ast_hash": "f95a0e467ad9c53eee28dc0af38d42ba",
     "semantic_hash": ""
   },
   "tests/test_auto_archive.py": {
-    "mtime": 1781586013.3718774,
+    "mtime": 1781742682.2908993,
     "ast_hash": "683b05b8e1c5fd9a5f4e253af537a4e8",
     "semantic_hash": ""
   },
   "tests/test_cockpit_splitter_resize.py": {
-    "mtime": 1780643732.8782256,
+    "mtime": 1781742682.307459,
     "ast_hash": "3f472a919870a64784736e05421af399",
     "semantic_hash": ""
   },
   "tests/test_fail_agent_notification.py": {
-    "mtime": 1779261472.5728981,
+    "mtime": 1781742682.3147388,
     "ast_hash": "32252f4c7a9b18d952ae8dde9f33c532",
     "semantic_hash": ""
   },
   "tests/test_juggle_hindsight.py": {
-    "mtime": 1779261472.5742414,
+    "mtime": 1781742682.3285937,
     "ast_hash": "6d861feba2c834d1c2faf347ecef8a55",
     "semantic_hash": ""
   },
   "tests/test_juggle_agent_settings.py": {
-    "mtime": 1780723371.5852349,
+    "mtime": 1781742682.327027,
     "ast_hash": "2d4382814675756b367ac75d0a329338",
     "semantic_hash": ""
   },
   "tests/test_hooks_askuser_action_item.py": {
-    "mtime": 1781083704.8881893,
+    "mtime": 1781742682.3240905,
     "ast_hash": "fab1511eb8d51cc9264f6bc665621e31",
     "semantic_hash": ""
   },
   "tests/test_cockpit.py": {
-    "mtime": 1780633993.5336328,
+    "mtime": 1781742682.2968998,
     "ast_hash": "71aa886560b97b701a1bd509cd5fa061",
     "semantic_hash": ""
   },
   "tests/test_juggle_selfheal.py": {
-    "mtime": 1781083704.8888326,
+    "mtime": 1781742682.3298883,
     "ast_hash": "dc26e32d5b331cf30586bc1a4c9125a4",
     "semantic_hash": ""
   },
   "tests/test_cockpit_static.py": {
-    "mtime": 1781129904.2268562,
+    "mtime": 1781742682.3078258,
     "ast_hash": "dd08075a7f5e2de4e12e93f32a8c1bc9",
     "semantic_hash": ""
   },
   "tests/test_reaper.py": {
-    "mtime": 1780703527.4999647,
+    "mtime": 1781742682.3402636,
     "ast_hash": "dd6c40404669111d6282ea3eb65f1125",
     "semantic_hash": ""
   },
   "tests/test_research_kb.py": {
-    "mtime": 1779261472.576034,
+    "mtime": 1781742682.3415997,
     "ast_hash": "000755f0cd1b14142a6d3d3d1e958c7d",
     "semantic_hash": ""
   },
   "tests/test_precompact.py": {
-    "mtime": 1781586013.373942,
+    "mtime": 1781742682.3376355,
     "ast_hash": "681e7edb3b3087460794e40a6b2e20d2",
     "semantic_hash": ""
   },
   "tests/test_cockpit_view.py": {
-    "mtime": 1781160534.958641,
+    "mtime": 1781742682.3089163,
     "ast_hash": "72cd193178a44716eaa61e8efed7db5c",
     "semantic_hash": ""
   },
   "tests/test_auto_action_items.py": {
-    "mtime": 1781669382.3518603,
+    "mtime": 1781742682.2906046,
     "ast_hash": "09e66c6ec7f15a83e9a112d22894d439",
     "semantic_hash": ""
   },
   "tests/test_juggle_settings.py": {
-    "mtime": 1781083704.8891387,
+    "mtime": 1781742682.330258,
     "ast_hash": "436473022cc7919bc0e79e73c977a699",
     "semantic_hash": ""
   },
   "tests/test_cockpit_snapshots.py": {
-    "mtime": 1779743365.4634707,
+    "mtime": 1781742682.3070977,
     "ast_hash": "946d4295cda7653f5c60fad6a01ddc9b",
     "semantic_hash": ""
   },
   "tests/test_agent_tool_telemetry.py": {
-    "mtime": 1781083704.8849547,
+    "mtime": 1781742682.2902439,
     "ast_hash": "fbed6749191ed99ada8c3d8cc1bcfaf3",
     "semantic_hash": ""
   },
   "tests/test_data_migration.py": {
-    "mtime": 1781682430.9449477,
+    "mtime": 1781742682.3101823,
     "ast_hash": "28831a532f26c95cbf5353a87d231e39",
     "semantic_hash": ""
   },
   "tests/test_thread_state_machine.py": {
-    "mtime": 1779261472.5766406,
+    "mtime": 1781742682.346026,
     "ast_hash": "d3f848e9317c870bbf326b6fa74a7000",
     "semantic_hash": ""
   },
   "tests/test_harness_codex.py": {
-    "mtime": 1780283433.723221,
+    "mtime": 1781742682.3230414,
     "ast_hash": "4f611ef8e400b37fd1aae6da8cb88a4d",
     "semantic_hash": ""
   },
   "tests/test_cockpit_readonly.py": {
-    "mtime": 1781391524.9427876,
+    "mtime": 1781742682.306448,
     "ast_hash": "e219068df6741a0485e4683b51079207",
     "semantic_hash": ""
   },
   "tests/test_cockpit_integration.py": {
-    "mtime": 1779743365.4630995,
+    "mtime": 1781742682.3031466,
     "ast_hash": "0988915816c3093e43a431b95736a275",
     "semantic_hash": ""
   },
   "tests/test_agent_monitor.py": {
-    "mtime": 1781083704.8845696,
+    "mtime": 1781742682.2882228,
     "ast_hash": "79a4e28aab66ce7636af02f84502a9a1",
     "semantic_hash": ""
   },
   "tests/test_open_questions.py": {
-    "mtime": 1781083704.8899894,
+    "mtime": 1781742682.3359482,
     "ast_hash": "a6439ec36423e4009bf8173371df0389",
     "semantic_hash": ""
   },
   "tests/test_doctor.py": {
-    "mtime": 1781586013.37334,
+    "mtime": 1781742682.314403,
     "ast_hash": "5604d2969da6eccd2dc7c12ab464c90a",
     "semantic_hash": ""
   },
   "tests/test_oneshot_observability.py": {
-    "mtime": 1781083704.8897834,
+    "mtime": 1781742682.3356276,
     "ast_hash": "d573a498b53749db1ac51bf556416860",
     "semantic_hash": ""
   },
   "tests/test_cheap_llm_call.py": {
-    "mtime": 1780283612.0220466,
+    "mtime": 1781742682.292074,
     "ast_hash": "6bbae6fb2456cb957321c3a1bf32e427",
     "semantic_hash": ""
   },
   "tests/test_llm_dispatch.py": {
-    "mtime": 1780633516.307008,
+    "mtime": 1781742682.3318264,
     "ast_hash": "676b222d395ca9c7a256e254e043f34b",
     "semantic_hash": ""
   },
   "tests/test_harness_conformance.py": {
-    "mtime": 1780283433.7233384,
+    "mtime": 1781742682.3231938,
     "ast_hash": "f950203691365c12b2ddf473f5386652",
     "semantic_hash": ""
   },
   "tests/test_cockpit_model.py": {
-    "mtime": 1781151172.9610229,
+    "mtime": 1781742682.3051207,
     "ast_hash": "ef780b094a8eefc943d8c5ff7c7be985",
     "semantic_hash": ""
   },
   "tests/test_fail_agent_routing.py": {
-    "mtime": 1779261472.5730932,
+    "mtime": 1781742682.3151257,
     "ast_hash": "1bee3d6d8c752cf641da3b26f9885463",
     "semantic_hash": ""
   },
   "tests/test_juggle_harness.py": {
-    "mtime": 1780283433.7236717,
+    "mtime": 1781742682.3282778,
     "ast_hash": "5fd1ddb05747688781b1f2032fbb14e7",
     "semantic_hash": ""
   },
   "tests/test_juggle_cli_memory.py": {
-    "mtime": 1781409551.6293104,
+    "mtime": 1781742682.327317,
     "ast_hash": "dcbf8bd7cfee218826593f6039413e7a",
     "semantic_hash": ""
   },
   "tests/test_juggle_db_agents.py": {
-    "mtime": 1780767511.0627491,
+    "mtime": 1781742682.327927,
     "ast_hash": "603ae7d9e56d8763c40aeb1e64e984f2",
     "semantic_hash": ""
   },
   "tests/test_agent_prompt_conventions.py": {
-    "mtime": 1781083704.8847551,
+    "mtime": 1781742682.288737,
     "ast_hash": "6d71214e03f0694e9b9c3c52789e8cb5",
     "semantic_hash": ""
   },
   "tests/test_projects.py": {
-    "mtime": 1780641693.9073646,
+    "mtime": 1781742682.3392801,
     "ast_hash": "ee1dec9fdcf28996bf1fc598314af175",
     "semantic_hash": ""
   },
   "tests/test_vault_commands.py": {
-    "mtime": 1780179114.7680802,
+    "mtime": 1781742682.3521204,
     "ast_hash": "a5a58f7956fdeeec06fbc520be10bfd5",
     "semantic_hash": ""
   },
   "tests/test_juggle_scheduler.py": {
-    "mtime": 1780712594.2792997,
+    "mtime": 1781742682.3294928,
     "ast_hash": "7af3daec23c36c9cdc00436cc9f4fab7",
     "semantic_hash": ""
   },
   "tests/test_notify_command.py": {
-    "mtime": 1779261472.575262,
+    "mtime": 1781742682.3348312,
     "ast_hash": "f189adbcf2b0568c3d519e3df9960963",
     "semantic_hash": ""
   },
   "tests/test_cockpit_profile.py": {
-    "mtime": 1779743365.6909297,
+    "mtime": 1781742682.3058686,
     "ast_hash": "89a6d8dcca559404656673f41596d5e1",
     "semantic_hash": ""
   },
   "tests/test_research_ingest.py": {
-    "mtime": 1779261472.575804,
+    "mtime": 1781742682.3411946,
     "ast_hash": "b0c4cfc3bdb36e75507590e1ada8910a",
     "semantic_hash": ""
   },
   "tests/test_cockpit_keys.py": {
-    "mtime": 1781597440.6482048,
+    "mtime": 1781742682.3037872,
     "ast_hash": "81e1f77e14f5ae3ed72daa3cbb5bacd3",
     "semantic_hash": ""
   },
   "tests/test_schedule_safety.py": {
-    "mtime": 1781083704.8906214,
+    "mtime": 1781742682.343248,
     "ast_hash": "499dedfb61e16ee3dbcc679c182f46aa",
     "semantic_hash": ""
   },
   "tests/test_juggle_watchdog.py": {
-    "mtime": 1779254200.4777677,
+    "mtime": 1781742682.3309805,
     "ast_hash": "8b3dec86b899b22704f4bc843fbb56cd",
     "semantic_hash": ""
   },
   "tests/test_harness_reasonix.py": {
-    "mtime": 1780283433.7234166,
+    "mtime": 1781742682.3234525,
     "ast_hash": "528093849098d9247dcffca65d4912eb",
     "semantic_hash": ""
   },
   "tests/test_single_db.py": {
-    "mtime": 1779261472.576446,
+    "mtime": 1781742682.3442276,
     "ast_hash": "f21d9604e49e585790a973e5422fbbdd",
     "semantic_hash": ""
   },
   "tests/test_juggle_db_memory.py": {
-    "mtime": 1781409551.6304364,
+    "mtime": 1781742682.3281758,
     "ast_hash": "4e8e352bc23a8c85f3dc6b3f932f4676",
     "semantic_hash": ""
   },
   "tests/test_title_gen.py": {
-    "mtime": 1780800420.688868,
+    "mtime": 1781742682.3464377,
     "ast_hash": "a0e65cd5939cf8003f47cc8d5b7f2566",
     "semantic_hash": ""
   },
   "tests/test_completion_commands.py": {
-    "mtime": 1780767511.0620465,
+    "mtime": 1781742682.3095725,
     "ast_hash": "9bbf8ab3d03894bd5dbbd7a73ea19120",
     "semantic_hash": ""
   },
   "tests/test_cmd_threads.py": {
-    "mtime": 1781591102.0871835,
+    "mtime": 1781742682.296312,
     "ast_hash": "5fd9c9c984b588026efb6477e8ae48ed",
     "semantic_hash": ""
   },
   "tests/test_talkback_device_cache.py": {
-    "mtime": 1779743365.746016,
+    "mtime": 1781742682.3451047,
     "ast_hash": "834ff009412faac8f330389ae9da333c",
     "semantic_hash": ""
   },
   "tests/test_juggle_hooks.py": {
-    "mtime": 1781588338.6458647,
+    "mtime": 1781742682.3288615,
     "ast_hash": "0b90b93247c5a985971e09349443f8e0",
     "semantic_hash": ""
   },
   "tests/test_cmd_context.py": {
-    "mtime": 1779261472.5715551,
+    "mtime": 1781742682.2945838,
     "ast_hash": "6f67be1ba8723c40b19e16bedc76d7f5",
     "semantic_hash": ""
   },
   "tests/test_vault_path_config.py": {
-    "mtime": 1779261472.5770156,
+    "mtime": 1781742682.3523533,
     "ast_hash": "f55d882a96894630e24b5c03e4df3403",
     "semantic_hash": ""
   },
   "tests/test_hooks_data_dir.py": {
-    "mtime": 1780166085.2421885,
+    "mtime": 1781742682.3246047,
     "ast_hash": "65b399a9ed54a41f3c05c34ec7c6a01d",
     "semantic_hash": ""
   },
   "tests/test_project_close_open.py": {
-    "mtime": 1781409551.6314828,
+    "mtime": 1781742682.3382812,
     "ast_hash": "09f760e0e6b8c694353168270c42927c",
     "semantic_hash": ""
   },
   "tests/test_projects_db.py": {
-    "mtime": 1780633594.9856575,
+    "mtime": 1781742682.3397639,
     "ast_hash": "5d41fe02075e9572ad8dcc74a747fe9d",
     "semantic_hash": ""
   },
   "tests/test_project_synth.py": {
-    "mtime": 1780641693.9071195,
+    "mtime": 1781742682.3387983,
     "ast_hash": "fbc9c1631189912ce847e30b7787210c",
     "semantic_hash": ""
   },
   "tests/schedule/conftest.py": {
-    "mtime": 1779746441.9789374,
+    "mtime": 1781742682.2857826,
     "ast_hash": "94458ec45aa470c84fa309abbf33a93e",
     "semantic_hash": ""
   },
   "tests/schedule/__init__.py": {
-    "mtime": 1779164140.4776082,
+    "mtime": 1781742682.285205,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": ""
   },
   "tests/schedule/test_schedule_reflect.py": {
-    "mtime": 1781083704.884359,
+    "mtime": 1781742682.2877882,
     "ast_hash": "f071313247affdd18ed6f3ec10bd137e",
     "semantic_hash": ""
   },
   "tests/schedule/test_schedule_autofix.py": {
-    "mtime": 1781083704.8837125,
+    "mtime": 1781742682.286187,
     "ast_hash": "226c32b74491cd370db4f0738c442aa4",
     "semantic_hash": ""
   },
   "tests/schedule/test_schedule_common.py": {
-    "mtime": 1781083704.8839338,
+    "mtime": 1781742682.2867992,
     "ast_hash": "ee6fb6286d1453aba5cde530d146776d",
     "semantic_hash": ""
   },
   "tests/schedule/test_schedule_dogfood.py": {
-    "mtime": 1781083704.8841403,
+    "mtime": 1781742682.287352,
     "ast_hash": "5acca3f73dce32feaa291e7e277b3a81",
     "semantic_hash": ""
   },
   "tests/auto-generated/2026-05-19-gaps.py": {
-    "mtime": 1779166855.237554,
+    "mtime": 1781742682.282464,
     "ast_hash": "e95ee1b7e9d5575592ff5618620da3f9",
     "semantic_hash": ""
   },
   "tests/watchdog/conftest.py": {
-    "mtime": 1779261472.578383,
+    "mtime": 1781742682.356379,
     "ast_hash": "a951e174fbdc66d94008122fe9b968a3",
     "semantic_hash": ""
   },
   "tests/watchdog/__init__.py": {
-    "mtime": 1779070735.9611013,
+    "mtime": 1781742682.3550994,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": ""
   },
   "tests/watchdog/test_baseline.py": {
-    "mtime": 1779261472.5786164,
+    "mtime": 1781742682.3610456,
     "ast_hash": "73606f118c8fbc51c7ba02dbf975e0c0",
     "semantic_hash": ""
   },
   "tests/watchdog/test_jh_regressions.py": {
-    "mtime": 1781083704.8924732,
+    "mtime": 1781742682.3631341,
     "ast_hash": "39a88b3a89bc45d3c5a7796897acfa51",
     "semantic_hash": ""
   },
   "tests/watchdog/test_watchdog_active.py": {
-    "mtime": 1779261472.5790553,
+    "mtime": 1781742682.365418,
     "ast_hash": "770dcc69f28065ff9d90b00929555f5f",
     "semantic_hash": ""
   },
   "scripts/measure_agent_compliance.py": {
-    "mtime": 1779314244.6646836,
+    "mtime": 1781742682.23556,
     "ast_hash": "41a454bf736d244387c9315f46170ddb",
     "semantic_hash": ""
   },
   "scripts/consolidate_dbs.py": {
-    "mtime": 1779314242.4281018,
+    "mtime": 1781742682.2327528,
     "ast_hash": "f52f647acec615695bcdb60900b8ea9b",
     "semantic_hash": ""
   },
   "src/juggle_schedule_common.py": {
-    "mtime": 1781083704.8814166,
+    "mtime": 1781742682.2723038,
     "ast_hash": "cd03a5fa693cdbdf5adf1e0c3b877020",
     "semantic_hash": ""
   },
   "src/juggle_db.py": {
-    "mtime": 1781676014.8018827,
+    "mtime": 1781742682.2622006,
     "ast_hash": "f4f3fc3cbd21deb2d9762c888fac6ce1",
     "semantic_hash": ""
   },
   "src/juggle_cmd_threads.py": {
-    "mtime": 1781588338.643777,
+    "mtime": 1781742682.2554343,
     "ast_hash": "acc69a11e9f84c88b2dd564d98fef6d2",
     "semantic_hash": ""
   },
   "src/juggle_cmd_context.py": {
-    "mtime": 1781409551.6213148,
+    "mtime": 1781742682.2523825,
     "ast_hash": "98b583802f6be616e7f0cc1bfe817750",
     "semantic_hash": ""
   },
   "src/juggle_cmd_search.py": {
-    "mtime": 1781734908.6425967,
+    "mtime": 1781742682.2551587,
     "ast_hash": "7faa1333fc00393cd022dbb237d36e4b",
     "semantic_hash": ""
   },
   "src/juggle_hooks.py": {
-    "mtime": 1781409551.6237388,
+    "mtime": 1781742682.266125,
     "ast_hash": "bf8d36444bb6fa7473f5e8d82a6b4ed4",
     "semantic_hash": ""
   },
   "src/juggle_tmux.py": {
-    "mtime": 1781082289.116379,
+    "mtime": 1781742682.277019,
     "ast_hash": "a5c432ed554ef110b348add543e6f5d6",
     "semantic_hash": ""
   },
   "src/juggle_research_ingest.py": {
-    "mtime": 1781734908.6430178,
+    "mtime": 1781742682.2710252,
     "ast_hash": "2b716c471717a097027019677a7efe0d",
     "semantic_hash": ""
   },
   "src/juggle_schedule_autofix.py": {
-    "mtime": 1781083704.881214,
+    "mtime": 1781742682.271915,
     "ast_hash": "06cc970650765f96554c3bf4d24fa5bd",
     "semantic_hash": ""
   },
   "src/juggle_schedule_reflect.py": {
-    "mtime": 1781083704.8818035,
+    "mtime": 1781742682.2739015,
     "ast_hash": "5b4ba7061885571322a412f2d35166ea",
     "semantic_hash": ""
   },
   "src/juggle_migrate_lifecycle.py": {
-    "mtime": 1781588805.9625926,
+    "mtime": 1781742682.2698996,
     "ast_hash": "54847669df3c28136afd92d3c4e4cb71",
     "semantic_hash": ""
   },
   "src/juggle_harness.py": {
-    "mtime": 1780283433.7223952,
+    "mtime": 1781742682.26557,
     "ast_hash": "e4ec6e60d3751c3aa5cb918639859883",
     "semantic_hash": ""
   },
   "src/juggle_cockpit.py": {
-    "mtime": 1781675947.651157,
+    "mtime": 1781742682.2559264,
     "ast_hash": "d1217e316f12034b5c72269866530763",
     "semantic_hash": ""
   },
   "src/juggle_watchdog.py": {
-    "mtime": 1781505936.7893577,
+    "mtime": 1781742682.2777052,
     "ast_hash": "32239d41884c99ae0d252ec6535c715b",
     "semantic_hash": ""
   },
   "src/juggle_cli.py": {
-    "mtime": 1781129904.2104654,
+    "mtime": 1781742682.2474453,
     "ast_hash": "146424588e297fc483d58f3c924b1e02",
     "semantic_hash": ""
   },
   "src/juggle_scheduler.py": {
-    "mtime": 1780800420.6853516,
+    "mtime": 1781742682.2744365,
     "ast_hash": "7491f4558e4f344a49695f78e35db94d",
     "semantic_hash": ""
   },
   "src/juggle_cmd_doctor.py": {
-    "mtime": 1781676014.7997265,
+    "mtime": 1781742682.2529306,
     "ast_hash": "97eaa258f91c0a017b5cb0c3c0323402",
     "semantic_hash": ""
   },
   "src/juggle_cmd_research.py": {
-    "mtime": 1781734908.6416342,
+    "mtime": 1781742682.254663,
     "ast_hash": "e702d041d66cbb2f0f4baf1a7a57a48f",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_view.py": {
-    "mtime": 1781391524.933155,
+    "mtime": 1781742682.2609236,
     "ast_hash": "c3502d3eca3b09eba173fcabc77acbd0",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_helpers.py": {
-    "mtime": 1780291877.616325,
+    "mtime": 1781742682.2577713,
     "ast_hash": "b650dc0ba1902eb4d7fc7caf9476c871",
     "semantic_hash": ""
   },
   "src/juggle_project_summary.py": {
-    "mtime": 1781083704.881028,
+    "mtime": 1781742682.270683,
     "ast_hash": "dd9fdc0c85cbb2442bd5375cb523f22d",
     "semantic_hash": ""
   },
   "src/juggle_cmd_projects.py": {
-    "mtime": 1781586013.3713615,
+    "mtime": 1781742682.2543535,
     "ast_hash": "a6cfd324715ccf1dd98b4ba104b6e6df",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_model.py": {
-    "mtime": 1781676014.800657,
+    "mtime": 1781742682.2588053,
     "ast_hash": "6e37b82e60084fd2f8eaac14ea414421",
     "semantic_hash": ""
   },
   "src/juggle_selfheal.py": {
-    "mtime": 1781682702.28339,
+    "mtime": 1781742682.275422,
     "ast_hash": "eb690bdd6044efc291ab38250059fe5b",
     "semantic_hash": ""
   },
   "src/juggle_cli_common.py": {
-    "mtime": 1781678274.911691,
+    "mtime": 1781742682.2477653,
     "ast_hash": "8f3b4f88f4ad3e0e232dfc0d5bb20b99",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_health.py": {
-    "mtime": 1781588338.6450129,
+    "mtime": 1781742682.2783253,
     "ast_hash": "ed7aaab94b33f290b2e5ec334b515f98",
     "semantic_hash": ""
   },
   "src/juggle_search_offline.py": {
-    "mtime": 1781734908.6441317,
+    "mtime": 1781742682.274886,
     "ast_hash": "b24d03a1d80533a5ff435c9eb77652d5",
     "semantic_hash": ""
   },
   "src/juggle_smoke.py": {
-    "mtime": 1781134131.4042141,
+    "mtime": 1781742682.276361,
     "ast_hash": "0c1a123e066fe7b2b9d934403e2132dd",
     "semantic_hash": ""
   },
   "src/juggle_context.py": {
-    "mtime": 1781409551.6226013,
+    "mtime": 1781742682.2615712,
     "ast_hash": "e18e0dcba73e202f51fca92be7d8830c",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_modals.py": {
-    "mtime": 1781680995.3555405,
+    "mtime": 1781742682.25848,
     "ast_hash": "1f95c5bbc09cabf56625e4388c48f4a8",
     "semantic_hash": ""
   },
   "src/juggle_settings.py": {
-    "mtime": 1781734908.6447597,
+    "mtime": 1781742682.2758949,
     "ast_hash": "5bcc58f9bce926f3483beee35914ba6f",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_widgets.py": {
-    "mtime": 1780643732.8780754,
+    "mtime": 1781742682.2612708,
     "ast_hash": "ab4f377ff1733c713d4be8ba5aca3d51",
     "semantic_hash": ""
   },
   "src/juggle_hindsight.py": {
-    "mtime": 1779261472.5668223,
+    "mtime": 1781742682.265891,
     "ast_hash": "7eb147cb206210b59358c4631f5e27fb",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents.py": {
-    "mtime": 1781588338.6433108,
+    "mtime": 1781742682.2491202,
     "ast_hash": "e92d5c0e8532c46c3fca1c29ffc46573",
     "semantic_hash": ""
   },
   "src/juggle_agent_settings.py": {
-    "mtime": 1780283433.7214324,
+    "mtime": 1781742682.2468314,
     "ast_hash": "012095ba5072e76db40c8e347c55be3b",
     "semantic_hash": ""
   },
   "src/juggle_research_kb.py": {
-    "mtime": 1779746441.977442,
+    "mtime": 1781742682.2714796,
     "ast_hash": "f5123b6d4985c1685ab8715a8810bbf7",
     "semantic_hash": ""
   },
   "src/juggle_schedule_dogfood.py": {
-    "mtime": 1781083704.8816285,
+    "mtime": 1781742682.2734082,
     "ast_hash": "6be1b4cf4a739c18da31211c2a138de2",
     "semantic_hash": ""
   },
   "src/harnesses/codex.py": {
-    "mtime": 1780283433.721276,
+    "mtime": 1781742682.2467165,
     "ast_hash": "3494680e83b20141ae2b81c014e27ea6",
     "semantic_hash": ""
   },
   "src/harnesses/claude.py": {
-    "mtime": 1780283433.72119,
+    "mtime": 1781742682.2466114,
     "ast_hash": "82ffaef7bfdda029133b36008a923aa3",
     "semantic_hash": ""
   },
   "src/harnesses/__init__.py": {
-    "mtime": 1780283433.7211096,
+    "mtime": 1781742682.2465217,
     "ast_hash": "8007e5efff996e427426f3269ce3f24f",
     "semantic_hash": ""
   },
   "CHANGELOG.md": {
-    "mtime": 1780788567.8791142,
+    "mtime": 1781742682.1375237,
     "ast_hash": "4d3a332dfa7e2da66194f0198b88ef8b",
     "semantic_hash": ""
   },
   "TODO.md": {
-    "mtime": 1781173128.6417193,
+    "mtime": 1781742682.138963,
     "ast_hash": "25fed78bd38a5061ec331bc6b74ff5f1",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1781130067.2757301,
+    "mtime": 1781742682.1385496,
     "ast_hash": "20c3c96af7bdde4edfa47b80d79dfde1",
     "semantic_hash": ""
   },
   "codex.md": {
-    "mtime": 1780179114.7597356,
+    "mtime": 1781742682.1390831,
     "ast_hash": "7c71b7b2315ac523ea3da295b0fedd32",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1780179114.7589812,
+    "mtime": 1781742682.1371534,
     "ast_hash": "7c71b7b2315ac523ea3da295b0fedd32",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1781083704.8651485,
-    "ast_hash": "65d0dcbe14e66800ee0b935826e45517",
+    "mtime": 1781742718.3428633,
+    "ast_hash": "4985451afbaf928beaee1a24d7a4ff8a",
     "semantic_hash": ""
   },
   "docker/docker-compose.yml": {
-    "mtime": 1777438972.854857,
+    "mtime": 1781742682.149935,
     "ast_hash": "92d2c158cb93d2e79721da600abc6d3c",
     "semantic_hash": ""
   },
   "config/viewports.yaml": {
-    "mtime": 1780629229.754192,
+    "mtime": 1781742682.1492307,
     "ast_hash": "a0d932c454ad0d5b938d1421e971c21d",
     "semantic_hash": ""
   },
   "plan/2026-05-17-juggle-agent-watchdog-plan.md": {
-    "mtime": 1779746441.9723961,
+    "mtime": 1781742682.227573,
     "ast_hash": "a355063f18e620269b81d6f153ce8482",
     "semantic_hash": ""
   },
   "plan/2026-05-17-domain-cleanup-vault-path-refactor-plan.md": {
-    "mtime": 1779059418.7142239,
+    "mtime": 1781742682.2269895,
     "ast_hash": "ad47595e1f1d3e633aac2afaedfc59ab",
     "semantic_hash": ""
   },
   "plan/2026-06-06-juggle-hardening.md": {
-    "mtime": 1780763369.9769018,
+    "mtime": 1781742682.2279053,
     "ast_hash": "b0ff9f43bf2818505e7a209a210aad18",
     "semantic_hash": ""
   },
   "tests/cockpit_snapshots/wide_140.txt": {
-    "mtime": 1779314441.2783058,
+    "mtime": 1781742682.2836816,
     "ast_hash": "3405d3158856d1aa890171a37f7cb2ec",
     "semantic_hash": ""
   },
   "tests/cockpit_snapshots/narrow_70.txt": {
-    "mtime": 1779314441.2849996,
+    "mtime": 1781742682.283085,
     "ast_hash": "dd05f7a4d33ab2762fdd21e8f791f52d",
     "semantic_hash": ""
   },
   "tests/cockpit_snapshots/medium_100.txt": {
-    "mtime": 1779314441.2820303,
+    "mtime": 1781742682.2828407,
     "ast_hash": "1786916f4ba4730cdc94ef3deb5beecf",
     "semantic_hash": ""
   },
   "tests/watchdog/README.md": {
-    "mtime": 1779071350.0529137,
+    "mtime": 1781742682.3550558,
     "ast_hash": "880e4ebae06039e194e17e286e20fd90",
     "semantic_hash": ""
   },
   "tests/watchdog/baseline-2026-05-17.txt": {
-    "mtime": 1779071003.0678618,
+    "mtime": 1781742682.355931,
     "ast_hash": "2ce8389fcb1289d77585b4251330a6d7",
     "semantic_hash": ""
   },
   "tests/watchdog/active-baseline-2026-05-17.txt": {
-    "mtime": 1779071006.370076,
+    "mtime": 1781742682.3554962,
     "ast_hash": "65fca4572af4fe46053379d39f5e0101",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/canonical-permission-prompt.txt": {
-    "mtime": 1779070793.9176722,
+    "mtime": 1781742682.3567557,
     "ast_hash": "a8f7e340fa57d76706859a50ae9e22ed",
     "semantic_hash": ""
   },
@@ -680,1603 +680,1583 @@
     "semantic_hash": ""
   },
   "docs/topic-lifecycle.md": {
-    "mtime": 1779748179.2725458,
+    "mtime": 1781742682.174096,
     "ast_hash": "88ba1efcb324c964bf7682f8def76d36",
     "semantic_hash": ""
   },
   "docs/harness-adapters.md": {
-    "mtime": 1781734908.6205754,
+    "mtime": 1781742682.1520376,
     "ast_hash": "9be191776542b6e58a8fd7e9247ff58c",
     "semantic_hash": ""
   },
   "docs/agent-context-injection.md": {
-    "mtime": 1779743365.3976018,
+    "mtime": 1781742682.1506424,
     "ast_hash": "57523a0a20fd3294f3cf226e2c34145b",
     "semantic_hash": ""
   },
   "docs/diagnosis-prompts.md": {
-    "mtime": 1780130262.742395,
+    "mtime": 1781742682.1517334,
     "ast_hash": "cd8dd4d33d9d3eeb631fe19f62ee9d3d",
     "semantic_hash": ""
   },
   "docs/research/2026-06-05-cockpit-reaping-smell.md": {
-    "mtime": 1780703527.4979396,
+    "mtime": 1781742682.1661744,
     "ast_hash": "1e1b8760c83200903e62e92cc17e1ff6",
     "semantic_hash": ""
   },
   "docs/research/2026-06-05-topic-dag-executor.md": {
-    "mtime": 1781129904.195249,
+    "mtime": 1781742682.167008,
     "ast_hash": "a074c19d598ff6cc7e0f36ef90a80347",
     "semantic_hash": ""
   },
   "docs/research/2026-06-05-topic-dag-executor-verdict.md": {
-    "mtime": 1781129904.1950765,
+    "mtime": 1781742682.1667373,
     "ast_hash": "9019d443056a181b61c7fc5bbf5e2162",
     "semantic_hash": ""
   },
   "docs/research/2026-06-05-agent-topic-context.md": {
-    "mtime": 1781129904.1946633,
+    "mtime": 1781742682.1658888,
     "ast_hash": "0cef9b068de5ae8373411418648a24b5",
     "semantic_hash": ""
   },
   "docs/research/2026-06-05-linux-scheduling.md": {
-    "mtime": 1781129904.194854,
+    "mtime": 1781742682.166455,
     "ast_hash": "7c1d8062a584ae535045d4feaf24c18a",
     "semantic_hash": ""
   },
   "docs/plans/2026-06-05-watchdog-sole-reaper.md": {
-    "mtime": 1780703527.4976907,
+    "mtime": 1781742682.1648893,
     "ast_hash": "f84e2fb990e4c36c70909ebfa98217af",
     "semantic_hash": ""
   },
   "docs/plans/2026-05-30-juggle-self-heal-on-error-plan.md": {
-    "mtime": 1780129067.6759384,
+    "mtime": 1781742682.1645942,
     "ast_hash": "adf43ddc9f2c7c7c683dc7d23800374a",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-05-project-assignment-automation.md": {
-    "mtime": 1780631743.214869,
+    "mtime": 1781742682.168045,
     "ast_hash": "e8931f54700f65b2c9be7b276f5efaa7",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-04-cockpit-viewport-smoke.md": {
-    "mtime": 1780630126.3588715,
+    "mtime": 1781742682.167691,
     "ast_hash": "606989bf7d8cc77127010bfd21a6c4bb",
     "semantic_hash": ""
   },
   "docs/specs/2026-05-30-juggle-self-heal-on-error.md": {
-    "mtime": 1780127601.1380095,
+    "mtime": 1781742682.167434,
     "ast_hash": "47a19f23b23c94fdd8f0e0052917982a",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-05-31-juggle-projects.md": {
-    "mtime": 1780283416.5592372,
+    "mtime": 1781742682.1705563,
     "ast_hash": "e8140aed443d7badb1a3e7517281a4c0",
     "semantic_hash": ""
   },
   "docs/superpowers/plans/2026-05-13-research-kb.md": {
-    "mtime": 1779743365.3981764,
+    "mtime": 1781742682.1701925,
     "ast_hash": "75df35eb5a5dfbfadcc42b3c558b16bc",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-13-research-kb-design.md": {
-    "mtime": 1779743365.3987463,
+    "mtime": 1781742682.1711457,
     "ast_hash": "f1970e9b452a84faf260d8ba74ab0cb2",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-17-juggle-agent-watchdog.md": {
-    "mtime": 1779071673.4273508,
+    "mtime": 1781742682.172221,
     "ast_hash": "59b4b219ab7175d02c8cf7c385c623cd",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-04-11-proactive-orchestrator-design.md": {
-    "mtime": 1775954982.721021,
+    "mtime": 1781742682.1708891,
     "ast_hash": "6255f6163cfd86c04eb35988ea89de0b",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-17-domain-cleanup-vault-path-refactor.md": {
-    "mtime": 1779059409.376419,
+    "mtime": 1781742682.1718938,
     "ast_hash": "7715817e44b529e3f87a5d2c2d5b1387",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-18-schedule-routines-design.md": {
-    "mtime": 1779090512.621734,
+    "mtime": 1781742682.172919,
     "ast_hash": "9d4541b940d490c133fc0e1febf82f54",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-16-agent-prompt-injection-design.md": {
-    "mtime": 1779746441.96026,
+    "mtime": 1781742682.171469,
     "ast_hash": "c0814ef1eecbbf6d4f8ce5a7e72b7f65",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-31-juggle-projects-design.md": {
-    "mtime": 1780283416.498772,
+    "mtime": 1781742682.1732066,
     "ast_hash": "d96eaa5c2447d7d8c3e142b447659c6a",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-06-03-classifier-correction-learning-plan.md": {
-    "mtime": 1780546775.743851,
+    "mtime": 1781742682.173579,
     "ast_hash": "6499af34c6baee7895e0eb15302388ec",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-05-17-watchdog-test-harness.md": {
-    "mtime": 1779746441.9604192,
+    "mtime": 1781742682.1725643,
     "ast_hash": "48695aeae27c8c83c908c6c916fe8d42",
     "semantic_hash": ""
   },
   "commands/open.md": {
-    "mtime": 1779314324.48329,
+    "mtime": 1781742682.1422257,
     "ast_hash": "6723e4f288b7ddfdd68b1ab9aaccdd78",
     "semantic_hash": ""
   },
   "commands/search-offline-db.md": {
-    "mtime": 1779327689.002545,
+    "mtime": 1781742682.1469846,
     "ast_hash": "7974bf98289c142bc378bc0d50601f03",
     "semantic_hash": ""
   },
   "commands/project:critique.md": {
-    "mtime": 1780295682.4039497,
+    "mtime": 1781742682.143532,
     "ast_hash": "4e9546a6c9e6da3aeacbd13fc6d14a1e",
     "semantic_hash": ""
   },
   "commands/search.md": {
-    "mtime": 1780179114.7629008,
+    "mtime": 1781742682.1472206,
     "ast_hash": "6b452ab85f40168da24da2d95ba27e17",
     "semantic_hash": ""
   },
   "commands/memory-stop.md": {
-    "mtime": 1775988256.1914222,
+    "mtime": 1781742682.141894,
     "ast_hash": "10cadcdad7ffb2cc8849fa41799c7bb0",
     "semantic_hash": ""
   },
   "commands/toggle-talkback.md": {
-    "mtime": 1776326191.099473,
+    "mtime": 1781742682.14822,
     "ast_hash": "1db5326d8101ac10ffd421768e12c2cf",
     "semantic_hash": ""
   },
   "commands/memory-start.md": {
-    "mtime": 1775988252.627605,
+    "mtime": 1781742682.141567,
     "ast_hash": "e046f944d52b764527a160098458d337",
     "semantic_hash": ""
   },
   "commands/capture.md": {
-    "mtime": 1780549199.3201957,
+    "mtime": 1781742682.1398082,
     "ast_hash": "385d17788d5cc81dd52a556f84bf1519",
     "semantic_hash": ""
   },
   "commands/doctor.md": {
-    "mtime": 1780179114.7622643,
+    "mtime": 1781742682.1408818,
     "ast_hash": "7422616b6e10e2f6dc271213d7084907",
     "semantic_hash": ""
   },
   "commands/remember.md": {
-    "mtime": 1779314324.4837093,
+    "mtime": 1781742682.145257,
     "ast_hash": "60886f97c100406852c6cfccb46aedb1",
     "semantic_hash": ""
   },
   "commands/resume-topic.md": {
-    "mtime": 1779814205.3555202,
+    "mtime": 1781742682.1459823,
     "ast_hash": "9a44abbe7bb9424cc87659dcb5a420ca",
     "semantic_hash": ""
   },
   "commands/project:create.md": {
-    "mtime": 1780295666.8600981,
+    "mtime": 1781742682.1432552,
     "ast_hash": "abf25b4463c235a681b4afc66b093524",
     "semantic_hash": ""
   },
   "commands/schedule.md": {
-    "mtime": 1780859802.810528,
+    "mtime": 1781742682.146616,
     "ast_hash": "776ed368ba37af862bd50d0f6ec394b3",
     "semantic_hash": ""
   },
   "commands/project:open.md": {
-    "mtime": 1780553641.2532074,
+    "mtime": 1781742682.1443858,
     "ast_hash": "8543ead1a7db1bd7985f5a5f563bb070",
     "semantic_hash": ""
   },
   "commands/init.md": {
-    "mtime": 1781735409.7296367,
+    "mtime": 1781742682.1413202,
     "ast_hash": "eddccfb99d87ea44bdd4f6be2a22dd0f",
     "semantic_hash": ""
   },
   "commands/research-ingest.md": {
-    "mtime": 1779314324.497086,
+    "mtime": 1781742682.1456363,
     "ast_hash": "2f30d714236c9df1c5f86fed830371f4",
     "semantic_hash": ""
   },
   "commands/_context-extraction.md": {
-    "mtime": 1779743365.3966696,
+    "mtime": 1781742682.139463,
     "ast_hash": "2e8bae08c02c04a34a6f904d84397f38",
     "semantic_hash": ""
   },
   "commands/project:edit.md": {
-    "mtime": 1780295678.4091206,
+    "mtime": 1781742682.1437826,
     "ast_hash": "11bfc793ccc15911ba996bc4321cade4",
     "semantic_hash": ""
   },
   "commands/deep-research.md": {
-    "mtime": 1780298351.6406405,
+    "mtime": 1781742682.1401587,
     "ast_hash": "eee93cf98c289405d032f5845165dadc",
     "semantic_hash": ""
   },
   "commands/project:close.md": {
-    "mtime": 1780553636.4490921,
+    "mtime": 1781742682.1428826,
     "ast_hash": "f79ffca90edaa8c79b9009f83244d0e0",
     "semantic_hash": ""
   },
   "commands/toggle-autopilot.md": {
-    "mtime": 1781391524.9204214,
+    "mtime": 1781742682.1478834,
     "ast_hash": "ad3a43cacc87d9003659cedf281f3b55",
     "semantic_hash": ""
   },
   "commands/project:show.md": {
-    "mtime": 1780295674.728939,
+    "mtime": 1781742682.145016,
     "ast_hash": "623106bb838f727eedc1f55846facbe8",
     "semantic_hash": ""
   },
   "commands/start.md": {
-    "mtime": 1781674177.1789563,
+    "mtime": 1781742682.1475677,
     "ast_hash": "cb7ce1b88c51a4163757f8eb25064f0c",
     "semantic_hash": ""
   },
   "commands/delegate.md": {
-    "mtime": 1781674177.1782494,
+    "mtime": 1781742682.1405663,
     "ast_hash": "9dce086efb4776e9a8caca11cfab6cbf",
     "semantic_hash": ""
   },
   "commands/project:list.md": {
-    "mtime": 1780553647.2936957,
+    "mtime": 1781742682.1440995,
     "ast_hash": "df9b0d30540ad9b211969bf69b80da05",
     "semantic_hash": ""
   },
   "skills/project:synthesis.md": {
-    "mtime": 1780633828.7673774,
+    "mtime": 1781742682.2369678,
     "ast_hash": "bd54d35f5a6cb00e27fd9c8f1acbb065",
     "semantic_hash": ""
   },
   "skills/talkback.md": {
-    "mtime": 1776326202.1244276,
+    "mtime": 1781742682.238886,
     "ast_hash": "be478786548ea1e39ad98f4ffacb0243",
     "semantic_hash": ""
   },
   "skills/schedule-autofix/SKILL.md": {
-    "mtime": 1779746441.9741564,
+    "mtime": 1781742682.2375422,
     "ast_hash": "8abde9f08869ad784493267c7aa354b2",
     "semantic_hash": ""
   },
   "skills/schedule-reflect/SKILL.md": {
-    "mtime": 1779746441.975982,
+    "mtime": 1781742682.2385767,
     "ast_hash": "8910018d92731286d2c19833ae14c205",
     "semantic_hash": ""
   },
   "skills/schedule-dogfood/SKILL.md": {
-    "mtime": 1779746441.9745426,
+    "mtime": 1781742682.2378848,
     "ast_hash": "e303269a0a80816f1ba48809954dc506",
     "semantic_hash": ""
   },
   "reports/dogfood-2026-06-01.md": {
-    "mtime": 1780331999.98451,
+    "mtime": 1781742682.2315826,
     "ast_hash": "8513e8deb1c43062017225c8c99d08df",
     "semantic_hash": ""
   },
   "reports/dogfood-2026-05-30.md": {
-    "mtime": 1780131685.848015,
+    "mtime": 1781742682.2312577,
     "ast_hash": "04964ce19f9fe2a8f33adc3394818cc5",
     "semantic_hash": ""
   },
   "reports/reflect-2026-06-01.md": {
-    "mtime": 1780331126.432151,
+    "mtime": 1781742682.232098,
     "ast_hash": "d22bd10533522c88090756ec5084a5a9",
     "semantic_hash": ""
   },
   "reports/reflect-2026-05-25.md": {
-    "mtime": 1779746441.972659,
+    "mtime": 1781742682.2318642,
     "ast_hash": "caad55f3af109239df0301bc50a9df38",
     "semantic_hash": ""
   },
   "docs/images/juggle-cockpit-v2.png": {
-    "mtime": 1779340578.5632448,
+    "mtime": 1781742682.1553664,
     "ast_hash": "3c8e5309165db746b5a253ed878b886e",
     "semantic_hash": ""
   },
   "docs/images/juggle-cockpit-v1.png": {
-    "mtime": 1779340426.4336877,
+    "mtime": 1781742682.1534052,
     "ast_hash": "8535b1174c16c79b6ceeff783527b333",
     "semantic_hash": ""
   },
   "docs/images/juggle-in-action.png": {
-    "mtime": 1780709582.5325654,
+    "mtime": 1781742682.162166,
     "ast_hash": "90591abe7cd41cf7fd2f944ad41caa8d",
     "semantic_hash": ""
   },
   "docs/assets/juggle-logo.svg": {
-    "mtime": 1778360876.8253865,
+    "mtime": 1781742682.1514673,
     "ast_hash": "5b68a09b44c8cb1858b748daac53147c",
     "semantic_hash": ""
   },
   "docs/assets/juggle-logo-dark.svg": {
-    "mtime": 1778360876.825231,
+    "mtime": 1781742682.151243,
     "ast_hash": "2b94a0be3b0d7377d085ce105b7506b0",
     "semantic_hash": ""
   },
   "docs/assets/juggle-icon.svg": {
-    "mtime": 1778360876.8249338,
+    "mtime": 1781742682.1510155,
     "ast_hash": "3b1183d4d694fd193e9f791aab7e1169",
     "semantic_hash": ""
   },
   ".claude-plugin/marketplace.json": {
-    "mtime": 1776544477.2617595,
+    "mtime": 1781742682.1348147,
     "ast_hash": "ac40c75daed6728f9e48809e39d29028",
     "semantic_hash": ""
   },
   ".claude-plugin/plugin.json": {
-    "mtime": 1781683355.8993573,
+    "mtime": 1781742682.135074,
     "ast_hash": "d6061dda698a1aab991b1eeea54cf111",
     "semantic_hash": ""
   },
   ".claude/settings.json": {
-    "mtime": 1778350739.978639,
+    "mtime": 1781742682.1358638,
     "ast_hash": "9276b535256dc065bd7b8b84e15abd95",
     "semantic_hash": ""
   },
   "hooks/hooks.json": {
-    "mtime": 1780541530.4597375,
+    "mtime": 1781742682.2263887,
     "ast_hash": "23f0bb897bf537c90a37532819c7e395",
     "semantic_hash": ""
   },
   "pyrightconfig.json": {
-    "mtime": 1775450611.7939985,
+    "mtime": 1781742682.2309198,
     "ast_hash": "9912b899818ff59d5c0a1f244cebf0a5",
     "semantic_hash": ""
   },
   "scripts/smoke_test_agent_compliance.sh": {
-    "mtime": 1779314329.0585465,
+    "mtime": 1781742682.2360032,
     "ast_hash": "998990aef1265fa6b21224c711d56586",
     "semantic_hash": ""
   },
   "tests/test_orchestrator_session_scope.py": {
-    "mtime": 1781083704.8901923,
+    "mtime": 1781742682.3368845,
     "ast_hash": "f0ab03b658ce82abd084c3b9bb0a19f8",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/crashed.sh": {
-    "mtime": 1779070801.1534371,
+    "mtime": 1781742682.3570292,
     "ast_hash": "01b9088b5b72d9ddfc6fbbea83ea2bfd",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/recoverable-prompt.sh": {
-    "mtime": 1779070788.8690956,
+    "mtime": 1781742682.3588002,
     "ast_hash": "93fbd3450f3b24010fce6884c163bd10",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/stalled-silent.sh": {
-    "mtime": 1779070799.0227823,
+    "mtime": 1781742682.3592584,
     "ast_hash": "ae6d677f5d96c234b316e09ca8951d3b",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/stuck-at-prompt.sh": {
-    "mtime": 1779071328.9705684,
+    "mtime": 1781742682.359623,
     "ast_hash": "45e86f0edc36cccf130a4aca08efe805",
     "semantic_hash": ""
   },
   "tests/watchdog/fixtures/working.sh": {
-    "mtime": 1779070774.0693586,
+    "mtime": 1781742682.3603399,
     "ast_hash": "ef787270e7107eff17e0f50e964ee5b6",
     "semantic_hash": ""
   },
   ".claude-plugin/skills/next-action.md": {
-    "mtime": 1776241703.5007553,
+    "mtime": 1781742682.1354527,
     "ast_hash": "a0784d6a6ef8759ee631232388bef633",
     "semantic_hash": ""
   },
   "plan/2026-06-07-worktree-always-integrate.md": {
-    "mtime": 1781129904.2039254,
+    "mtime": 1781742682.2283397,
     "ast_hash": "07acccd911f881b90f869c3506b59f29",
     "semantic_hash": ""
   },
   "src/juggle_cmd_integrate.py": {
-    "mtime": 1781664069.6226447,
+    "mtime": 1781742682.2537198,
     "ast_hash": "6fa57bbd34d0a1bbce5327e65ecb8504",
     "semantic_hash": ""
   },
   "tests/test_integrate.py": {
-    "mtime": 1781492490.4215515,
+    "mtime": 1781742682.3255458,
     "ast_hash": "b4e67af51de7a5356785121f00cb70ff",
     "semantic_hash": ""
   },
   "tests/test_worktree_setup.py": {
-    "mtime": 1781083704.8914995,
+    "mtime": 1781742682.3547335,
     "ast_hash": "3944cd4a1a56f6d4b76d37a806623a20",
     "semantic_hash": ""
   },
   "tests/test_get_agent_harness.py": {
-    "mtime": 1781083704.8877928,
+    "mtime": 1781742682.316406,
     "ast_hash": "1661f518b1f575e5c2caf6b473e5e39b",
     "semantic_hash": ""
   },
   "tests/test_harness_spawn_launch.py": {
-    "mtime": 1781083704.8879936,
+    "mtime": 1781742682.323824,
     "ast_hash": "b872f668613025bcd640ea7e150f4d6a",
     "semantic_hash": ""
   },
   "scripts/loc_gate.py": {
-    "mtime": 1781682430.942393,
+    "mtime": 1781742682.2352955,
     "ast_hash": "543fb54af0ac0591aae70e7a3d649d4d",
     "semantic_hash": ""
   },
   "tests/test_loc_gate.py": {
-    "mtime": 1781083704.8895502,
+    "mtime": 1781742682.3321965,
     "ast_hash": "897ac372a213b173ff96d0c81bee0de8",
     "semantic_hash": ""
   },
   "plan/2026-06-10-refactor-results.md": {
-    "mtime": 1781083704.8740153,
+    "mtime": 1781742682.2296958,
     "ast_hash": "3836606a893ac5849e26004d28b637e8",
     "semantic_hash": ""
   },
   "src/daemon_pidfile.py": {
-    "mtime": 1781083704.8748128,
+    "mtime": 1781742682.2393029,
     "ast_hash": "56bbca792dee6bea4b43bc844ba528ab",
     "semantic_hash": ""
   },
   "src/llm_calls.py": {
-    "mtime": 1781734908.6452796,
+    "mtime": 1781742682.2800438,
     "ast_hash": "7e30317345ca824e781c1e2b135351e3",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_inspect.py": {
-    "mtime": 1781083704.8823686,
+    "mtime": 1781742682.2787297,
     "ast_hash": "c74b03cdcfc4ffe9ad88ee5208fff37c",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_restart.py": {
-    "mtime": 1781489926.517088,
+    "mtime": 1781742682.2790697,
     "ast_hash": "76757c7a1b47410ed4bceee273db371a",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_layout.py": {
-    "mtime": 1781083704.879327,
+    "mtime": 1781742682.258106,
     "ast_hash": "eb534d83496583d3ca1cfb185de0d28e",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_profile.py": {
-    "mtime": 1781129904.2160788,
+    "mtime": 1781742682.259152,
     "ast_hash": "efc990ffd80b5c49713a60c30816250c",
     "semantic_hash": ""
   },
   "src/juggle_hooks_checkpoint.py": {
-    "mtime": 1781682702.2828016,
+    "mtime": 1781742682.2666097,
     "ast_hash": "340f8a4a974617f483f6449760e8ea73",
     "semantic_hash": ""
   },
   "src/juggle_hooks_classb.py": {
-    "mtime": 1781083704.8802016,
+    "mtime": 1781742682.2669542,
     "ast_hash": "56cd5475e325bed1558801cc7c224c5e",
     "semantic_hash": ""
   },
   "src/juggle_hooks_config.py": {
-    "mtime": 1781083704.8803394,
+    "mtime": 1781742682.2672124,
     "ast_hash": "0760c31e476d0c2054148a635b099991",
     "semantic_hash": ""
   },
   "src/juggle_hooks_prompt.py": {
-    "mtime": 1781409551.6241257,
+    "mtime": 1781742682.267578,
     "ast_hash": "ea60d5290f73443dda2ca23b3e3d4114",
     "semantic_hash": ""
   },
   "src/juggle_hooks_tooluse.py": {
-    "mtime": 1781083704.8806956,
+    "mtime": 1781742682.2681754,
     "ast_hash": "d0f17ef77233932f91b7261d0f55f844",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_common.py": {
-    "mtime": 1781083704.8775725,
+    "mtime": 1781742682.2495923,
     "ast_hash": "a44b25355b76a660daff57334b183122",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_lifecycle.py": {
-    "mtime": 1781509956.3953068,
+    "mtime": 1781742682.2509418,
     "ast_hash": "afb966aab9a98d58ab42ba22109d752f",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_complete.py": {
-    "mtime": 1781409551.6206536,
+    "mtime": 1781742682.2499094,
     "ast_hash": "9e4e64d4f5ab4dab204562c8e3255008",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_pool.py": {
-    "mtime": 1781083704.87802,
+    "mtime": 1781742682.2511942,
     "ast_hash": "e00805757909990815eda3ad42ccf667",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_tasks.py": {
-    "mtime": 1781395273.7737586,
+    "mtime": 1781742682.2514935,
     "ast_hash": "ec7dd304eee9a5fd7380efb59d3cfef7",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_worktree.py": {
-    "mtime": 1781193888.40104,
+    "mtime": 1781742682.2517543,
     "ast_hash": "1d197e5cb4d5c7d12c124fc87a4af3c6",
     "semantic_hash": ""
   },
   "src/juggle_cli_parsers_agents.py": {
-    "mtime": 1781409551.6197388,
+    "mtime": 1781742682.2480466,
     "ast_hash": "05fcdf42023430be8f4a45d606a78d1a",
     "semantic_hash": ""
   },
   "src/juggle_cli_parsers_misc.py": {
-    "mtime": 1781682702.2816885,
+    "mtime": 1781742682.2483587,
     "ast_hash": "d8d988cca49fa6fbb96004aa59faa6c9",
     "semantic_hash": ""
   },
   "src/juggle_cli_parsers_threads.py": {
-    "mtime": 1781409551.6203542,
+    "mtime": 1781742682.248731,
     "ast_hash": "e973081476899dfabad14abb6fa80c47",
     "semantic_hash": ""
   },
   "src/juggle_cmd_misc.py": {
-    "mtime": 1781682702.2822325,
+    "mtime": 1781742682.2539666,
     "ast_hash": "b7a731bc3c3c0e6d93f6fb0056058724",
     "semantic_hash": ""
   },
   "src/schedules/__init__.py": {
-    "mtime": 1781083704.8828185,
+    "mtime": 1781742682.2803473,
     "ast_hash": "0fd86050c8d4fffaf5285495def630a8",
     "semantic_hash": ""
   },
   "src/schedules/autofix.py": {
-    "mtime": 1781083704.8830042,
+    "mtime": 1781742682.2807238,
     "ast_hash": "71a67f25e99e2821f3849608f922cfbb",
     "semantic_hash": ""
   },
   "src/schedules/common.py": {
-    "mtime": 1781083704.883159,
+    "mtime": 1781742682.2810822,
     "ast_hash": "5a2acc87cad2f5332c0cd310e7b0810d",
     "semantic_hash": ""
   },
   "src/schedules/dogfood.py": {
-    "mtime": 1781083704.8833406,
+    "mtime": 1781742682.2814002,
     "ast_hash": "2f37717066b13612ea09af7c24b69e41",
     "semantic_hash": ""
   },
   "src/schedules/reflect.py": {
-    "mtime": 1781132488.5635602,
+    "mtime": 1781742682.2816708,
     "ast_hash": "b5de324841b8a6b6c08e6a51449b847e",
     "semantic_hash": ""
   },
   "src/dbops/__init__.py": {
-    "mtime": 1781083704.8749793,
+    "mtime": 1781742682.2397058,
     "ast_hash": "a4057404b94ce2152c301c8efbd1ca70",
     "semantic_hash": ""
   },
   "src/dbops/agents.py": {
-    "mtime": 1781509956.3944979,
+    "mtime": 1781742682.2401738,
     "ast_hash": "29f24b3352dff4de865572f6adf9b170",
     "semantic_hash": ""
   },
   "src/dbops/messages.py": {
-    "mtime": 1781083704.8752878,
+    "mtime": 1781742682.2426097,
     "ast_hash": "cde6fb6806cc82ce823e4b4a1c8b9e1c",
     "semantic_hash": ""
   },
   "src/dbops/migrations.py": {
-    "mtime": 1781588805.9619975,
+    "mtime": 1781742682.2429662,
     "ast_hash": "6c771755a2de5891b4d44a6567d15604",
     "semantic_hash": ""
   },
   "src/dbops/notifications.py": {
-    "mtime": 1781669382.3504074,
+    "mtime": 1781742682.2439609,
     "ast_hash": "1e5ab923c9cec1c7842982c167956cae",
     "semantic_hash": ""
   },
   "src/dbops/projects.py": {
-    "mtime": 1781409551.6184118,
+    "mtime": 1781742682.244333,
     "ast_hash": "b2769900a0a0fbb8ab2fdaa066417b34",
     "semantic_hash": ""
   },
   "src/dbops/schema.py": {
-    "mtime": 1781669382.3508341,
+    "mtime": 1781742682.2450264,
     "ast_hash": "77b7933e0798903cffabae85b4d36188",
     "semantic_hash": ""
   },
   "src/dbops/selfheal.py": {
-    "mtime": 1781083704.8760655,
+    "mtime": 1781742682.2457235,
     "ast_hash": "bf39e760c9f8150f7eb723f15c98daad",
     "semantic_hash": ""
   },
   "src/dbops/session.py": {
-    "mtime": 1781129904.2099721,
+    "mtime": 1781742682.246046,
     "ast_hash": "a4567fa1c033d2476f8476d19f3a4f9b",
     "semantic_hash": ""
   },
   "src/dbops/threads.py": {
-    "mtime": 1781678274.9111211,
+    "mtime": 1781742682.246354,
     "ast_hash": "5b372e46508b84546d3f5d2468df0138",
     "semantic_hash": ""
   },
   "src/juggle_monitor_daemon.py": {
-    "mtime": 1781676014.8027875,
+    "mtime": 1781742682.270262,
     "ast_hash": "5cb7db6f144fc6ac00fa752eb5be82c6",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_daemon.py": {
-    "mtime": 1781682702.2844245,
+    "mtime": 1781742682.2780566,
     "ast_hash": "c3172f7de3022e95f3b0e6a8d86330c2",
     "semantic_hash": ""
   },
   "tests/watchdog/test_actionable_items.py": {
-    "mtime": 1781083704.8916698,
+    "mtime": 1781742682.3607764,
     "ast_hash": "9b562d7046413ed31f65991f805bb605",
     "semantic_hash": ""
   },
   "tests/watchdog/test_db_events.py": {
-    "mtime": 1781083704.891812,
+    "mtime": 1781742682.3617022,
     "ast_hash": "b047d3fe48bcefe4010c3cab5696181b",
     "semantic_hash": ""
   },
   "tests/watchdog/test_hardening.py": {
-    "mtime": 1781083704.89197,
+    "mtime": 1781742682.3620207,
     "ast_hash": "f9ee5604ca3f88a7e1339f8557a6503d",
     "semantic_hash": ""
   },
   "tests/watchdog/test_health.py": {
-    "mtime": 1781083704.8921154,
+    "mtime": 1781742682.3622537,
     "ast_hash": "60642642c1333da084cc02d7823fc211",
     "semantic_hash": ""
   },
   "tests/watchdog/test_integration.py": {
-    "mtime": 1781083704.892267,
+    "mtime": 1781742682.3625813,
     "ast_hash": "b229a5ba9f1633a67a55f499d0c7b507",
     "semantic_hash": ""
   },
   "tests/watchdog/test_never_tasked.py": {
-    "mtime": 1781083704.8926227,
+    "mtime": 1781742682.3635902,
     "ast_hash": "a661d58c73463921991150cf1e087d64",
     "semantic_hash": ""
   },
   "tests/watchdog/test_policy.py": {
-    "mtime": 1781083704.8927805,
+    "mtime": 1781742682.3639772,
     "ast_hash": "2a96bcc2070c6e4a57cc6bc7afd174e0",
     "semantic_hash": ""
   },
   "tests/watchdog/test_reaper_ownership.py": {
-    "mtime": 1781391524.953241,
+    "mtime": 1781742682.3642461,
     "ast_hash": "5bffe47af4bd02085e4461baf2654e18",
     "semantic_hash": ""
   },
   "tests/watchdog/test_recovery_event_regressions.py": {
-    "mtime": 1781083704.8930779,
+    "mtime": 1781742682.3645175,
     "ast_hash": "f5a393c9c9890a883740445cfe543634",
     "semantic_hash": ""
   },
   "tests/watchdog/test_stall_regressions.py": {
-    "mtime": 1781083704.8932498,
+    "mtime": 1781742682.3648045,
     "ast_hash": "daae97a065709d73285a3231bba8b975",
     "semantic_hash": ""
   },
   "tests/watchdog/test_watchdog.py": {
-    "mtime": 1781083704.8934066,
+    "mtime": 1781742682.3651206,
     "ast_hash": "0a5b79a5d88b91b760ce8131c42b338b",
     "semantic_hash": ""
   },
   "tests/test_cli_agents.py": {
-    "mtime": 1781083704.8853161,
+    "mtime": 1781742682.292476,
     "ast_hash": "7ce13c48046b0be0a70c4349d00c912a",
     "semantic_hash": ""
   },
   "tests/test_cli_editor.py": {
-    "mtime": 1781083704.8854833,
+    "mtime": 1781742682.292799,
     "ast_hash": "d3ff99ab97e91063d3ee981c559a049d",
     "semantic_hash": ""
   },
   "tests/test_cli_flags.py": {
-    "mtime": 1781083704.8856242,
+    "mtime": 1781742682.293109,
     "ast_hash": "a7e09bb1eccbbdc407739150aede701f",
     "semantic_hash": ""
   },
   "tests/test_cli_threads.py": {
-    "mtime": 1781586013.372095,
+    "mtime": 1781742682.2934833,
     "ast_hash": "743436f431d5cdc90a07625f49294d95",
     "semantic_hash": ""
   },
   "tests/test_tmux_lifecycle.py": {
-    "mtime": 1781083704.8907962,
+    "mtime": 1781742682.3495917,
     "ast_hash": "bdfd70aca62822e6bea8b029dd06f994",
     "semantic_hash": ""
   },
   "tests/test_tmux_send_message.py": {
-    "mtime": 1781083704.8909497,
+    "mtime": 1781742682.349888,
     "ast_hash": "4028ad9ae691239a48d1440029701d62",
     "semantic_hash": ""
   },
   "tests/test_tmux_send_task.py": {
-    "mtime": 1781083704.891098,
+    "mtime": 1781742682.3505025,
     "ast_hash": "4133db8e172ea89f180a0e785f999a86",
     "semantic_hash": ""
   },
   "tests/test_tmux_submission.py": {
-    "mtime": 1781083704.8912563,
+    "mtime": 1781742682.3508127,
     "ast_hash": "fd7a251dcfac6cb243a7fc364d5ffb1c",
     "semantic_hash": ""
   },
   "tests/test_db_archive.py": {
-    "mtime": 1781586013.372866,
+    "mtime": 1781742682.3104384,
     "ast_hash": "e02dd3f2c3ba8319610e660256cf80e7",
     "semantic_hash": ""
   },
   "tests/test_db_messages.py": {
-    "mtime": 1781083704.8869874,
+    "mtime": 1781742682.3117702,
     "ast_hash": "7f7b854d27bdf002221f3fadb0c89426",
     "semantic_hash": ""
   },
   "tests/test_db_migrations.py": {
-    "mtime": 1781409551.6279187,
+    "mtime": 1781742682.3121054,
     "ast_hash": "fdcf32fb555be77cecfb604fd27787ca",
     "semantic_hash": ""
   },
   "tests/test_db_thread_state.py": {
-    "mtime": 1781083704.8874285,
+    "mtime": 1781742682.313029,
     "ast_hash": "23ed97346000bccdf5b534355932f15d",
     "semantic_hash": ""
   },
   "tests/test_db_threads.py": {
-    "mtime": 1781586013.3731604,
+    "mtime": 1781742682.3133142,
     "ast_hash": "3653a5eb0f9e40521784d331af8fcd9a",
     "semantic_hash": ""
   },
   "tests/test_cockpit_actions.py": {
-    "mtime": 1781083704.8859475,
+    "mtime": 1781742682.2974622,
     "ast_hash": "a5eb105b7df4ce33e72ee88a1cf78046",
     "semantic_hash": ""
   },
   "tests/test_cockpit_bell.py": {
-    "mtime": 1781083704.886096,
+    "mtime": 1781742682.2977588,
     "ast_hash": "912038fdbbc6962d10fce0c5ab137a5d",
     "semantic_hash": ""
   },
   "tests/test_cockpit_filter.py": {
-    "mtime": 1781083704.886243,
+    "mtime": 1781742682.2980783,
     "ast_hash": "621b5c77ee9930af8d162c8b97941566",
     "semantic_hash": ""
   },
   "tests/test_cockpit_tail_drawer.py": {
-    "mtime": 1781083704.8865209,
+    "mtime": 1781742682.3079965,
     "ast_hash": "aecf1a92bbca869ef55a989442e31d89",
     "semantic_hash": ""
   },
   "tests/test_cockpit_model_snapshot.py": {
-    "mtime": 1781083704.8863804,
+    "mtime": 1781742682.305473,
     "ast_hash": "d2d4c2e57bf02eecc74e60c29a1f4d56",
     "semantic_hash": ""
   },
   "tests/test_context_injection.py": {
-    "mtime": 1781586013.3724391,
+    "mtime": 1781742682.3098352,
     "ast_hash": "9e28085695e4df8f2e379ea9aec96d2d",
     "semantic_hash": ""
   },
   "tests/test_db_schema.py": {
-    "mtime": 1781151172.9621406,
+    "mtime": 1781742682.3126907,
     "ast_hash": "525e821e88ff3d1909e0150471329a29",
     "semantic_hash": ""
   },
   "docs/ARCHITECTURE.md": {
-    "mtime": 1781083704.8659632,
+    "mtime": 1781742682.1503878,
     "ast_hash": "d1071b7802b75a9f3500720beae6f7a8",
     "semantic_hash": ""
   },
   "src/juggle_smoke_pty.py": {
-    "mtime": 1781153623.565063,
+    "mtime": 1781742682.2767117,
     "ast_hash": "9b452b7db56d4ed5249a5cb61fd55f9e",
     "semantic_hash": ""
   },
   "src/dbops/migrations_recent.py": {
-    "mtime": 1781586013.3696237,
+    "mtime": 1781742682.2435923,
     "ast_hash": "b55ac9b2077530d222bc3425da552d03",
     "semantic_hash": ""
   },
   "src/juggle_context_startup.py": {
-    "mtime": 1781409551.6232257,
+    "mtime": 1781742682.2619278,
     "ast_hash": "deedf6beb0f8fe36dd33a9bd4f95b7d1",
     "semantic_hash": ""
   },
   "src/dbops/db_graph.py": {
-    "mtime": 1781391524.9211075,
+    "mtime": 1781742682.2405481,
     "ast_hash": "e71571b92f3fac2f37813a07dbe24388",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_graph.py": {
-    "mtime": 1781504683.2755842,
+    "mtime": 1781742682.2502794,
     "ast_hash": "ca0bf3692de0aeb182216b6e2972eee7",
     "semantic_hash": ""
   },
   "src/juggle_cmd_graph.py": {
-    "mtime": 1781393823.1921947,
+    "mtime": 1781742682.253338,
     "ast_hash": "1603096cdaf53ee4cef2a150e308058a",
     "semantic_hash": ""
   },
   "tests/test_cmd_graph.py": {
-    "mtime": 1781391524.939276,
+    "mtime": 1781742682.2950532,
     "ast_hash": "6c2714a70a7f3d73d59fc93ecd342f92",
     "semantic_hash": ""
   },
   "tests/test_db_graph.py": {
-    "mtime": 1781391524.9432845,
+    "mtime": 1781742682.3111675,
     "ast_hash": "7a7d57ce487361273fd5cd76efeb0ec5",
     "semantic_hash": ""
   },
   "tests/test_graph_marking.py": {
-    "mtime": 1781391524.9484642,
+    "mtime": 1781742682.3207114,
     "ast_hash": "ca53162251a765f716673d5eab78e6cb",
     "semantic_hash": ""
   },
   "src/juggle_graph_dispatch.py": {
-    "mtime": 1781592098.8425126,
+    "mtime": 1781742682.2637553,
     "ast_hash": "3a3e8bd6fd2569f680e88ea9e8eadb70",
     "semantic_hash": ""
   },
   "tests/test_graph_dispatch.py": {
-    "mtime": 1781592098.844427,
+    "mtime": 1781742682.3186667,
     "ast_hash": "bba4771a8b573d7a562911c742702b6c",
     "semantic_hash": ""
   },
   "tests/test_graph_autopilot_integration.py": {
-    "mtime": 1781592098.8436806,
+    "mtime": 1781742682.317948,
     "ast_hash": "99b6b279e70316c024197377e3c29593",
     "semantic_hash": ""
   },
   "tests/test_graph_contract.py": {
-    "mtime": 1781592098.8439448,
+    "mtime": 1781742682.3183372,
     "ast_hash": "b3d2c0b36288d80b1e319c7ebcc1e708",
     "semantic_hash": ""
   },
   "src/juggle_integrate_lock.py": {
-    "mtime": 1781391524.936242,
+    "mtime": 1781742682.2685506,
     "ast_hash": "aec74c1ce621d2a81157e087b0b5ef99",
     "semantic_hash": ""
   },
   "src/juggle_integrate_selfrepo.py": {
-    "mtime": 1781492556.8461826,
+    "mtime": 1781742682.2688982,
     "ast_hash": "36ee4c3e320a6ab4d2462c30b2728293",
     "semantic_hash": ""
   },
   "src/juggle_integrate_verify.py": {
-    "mtime": 1781391524.936564,
+    "mtime": 1781742682.2694724,
     "ast_hash": "18d368ca7c8f47f19f3719cce56d27b0",
     "semantic_hash": ""
   },
   "tests/test_integrate_verify.py": {
-    "mtime": 1781391524.9513166,
+    "mtime": 1781742682.3264499,
     "ast_hash": "18d0c254006114e8e9dde57f08482e67",
     "semantic_hash": ""
   },
   "src/dbops/db_graph_marking.py": {
-    "mtime": 1781391524.9220233,
+    "mtime": 1781742682.240848,
     "ast_hash": "e3f74deff77195d99737639fe97c25e4",
     "semantic_hash": ""
   },
   "tests/test_graph_failure_propagation.py": {
-    "mtime": 1781391524.9473104,
+    "mtime": 1781742682.3192663,
     "ast_hash": "db4c047ebc456c83e55c0c768c9338c6",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_sched.py": {
-    "mtime": 1781129904.2163959,
+    "mtime": 1781742682.2594516,
     "ast_hash": "ebe14c12d1709799eb37460ed89e2a6f",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_static.py": {
-    "mtime": 1781129904.2168782,
+    "mtime": 1781742682.260188,
     "ast_hash": "5ffaffb66d22c0448f575d8d1031eab5",
     "semantic_hash": ""
   },
   "src/juggle_hooks_autopilot.py": {
-    "mtime": 1781391524.9359357,
+    "mtime": 1781742682.266377,
     "ast_hash": "76dc7b4f14f9f6e77efd87a79f0ee120",
     "semantic_hash": ""
   },
   "src/juggle_cmd_autopilot.py": {
-    "mtime": 1781391524.927005,
+    "mtime": 1781742682.25209,
     "ast_hash": "90c745debcf845e70514b35b4092674f",
     "semantic_hash": ""
   },
   "src/juggle_graph_status.py": {
-    "mtime": 1781391524.9354446,
+    "mtime": 1781742682.2651587,
     "ast_hash": "f0f0ec3144d62201cb2cfc36cfd8dd5b",
     "semantic_hash": ""
   },
   "tests/test_cmd_autopilot.py": {
-    "mtime": 1781391524.9390233,
+    "mtime": 1781742682.2939708,
     "ast_hash": "3f1a48cc02c1b9addb150d475daeb552",
     "semantic_hash": ""
   },
   "tests/test_graph_status.py": {
-    "mtime": 1781391524.9502861,
+    "mtime": 1781742682.3224406,
     "ast_hash": "5a957c2031dfed904197a6327f16ef96",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph.py": {
-    "mtime": 1781391524.9399183,
+    "mtime": 1781742682.299407,
     "ast_hash": "7020726418b946b4fb7fd1b620522a63",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_snapshots.py": {
-    "mtime": 1781129904.224835,
+    "mtime": 1781742682.279806,
     "ast_hash": "dfdbd5ad397d4084a351558ac018e76a",
     "semantic_hash": ""
   },
   "tests/test_graph_agent_death.py": {
-    "mtime": 1781391524.944903,
+    "mtime": 1781742682.317337,
     "ast_hash": "d775beda4697597479f1a915c21ffede",
     "semantic_hash": ""
   },
   "src/juggle_graph_hydration.py": {
-    "mtime": 1781391524.934797,
+    "mtime": 1781742682.264356,
     "ast_hash": "012233c69b8d5f5b296c5547ba204bc9",
     "semantic_hash": ""
   },
   "src/dbops/db_topics.py": {
-    "mtime": 1781592098.840395,
+    "mtime": 1781742682.241619,
     "ast_hash": "a37cc40a3c74c3a70dc9e75477f81842",
     "semantic_hash": ""
   },
   "src/dbops/migrations_graph.py": {
-    "mtime": 1781592098.841488,
+    "mtime": 1781742682.2432632,
     "ast_hash": "cbf507eaedee95f704ba7b18fb7e873a",
     "semantic_hash": ""
   },
   "src/dbops/schema_graph.py": {
-    "mtime": 1781592098.8418865,
+    "mtime": 1781742682.2452514,
     "ast_hash": "fc38c2a8ff24f8ad8369832e623d685b",
     "semantic_hash": ""
   },
   "src/juggle_autopilot_state.py": {
-    "mtime": 1781162636.0527315,
+    "mtime": 1781742682.2471707,
     "ast_hash": "d5935b8b8e78afa29e8ca840c2933bbd",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_graph_dag.py": {
-    "mtime": 1781585989.0017805,
+    "mtime": 1781742682.2565234,
     "ast_hash": "61f0b65961f704b4439337d55272fc2f",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_graph_layout.py": {
-    "mtime": 1781504683.278852,
+    "mtime": 1781742682.2568517,
     "ast_hash": "c34fb865628ef320ee13826945bebb06",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_graph_mode.py": {
-    "mtime": 1781585989.0024269,
+    "mtime": 1781742682.2571118,
     "ast_hash": "b94b354fcd8aa54e1d40ab6044bb1a33",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_graph_panel.py": {
-    "mtime": 1781588317.4006348,
+    "mtime": 1781742682.2574146,
     "ast_hash": "56a66023f1d6b4e89905ad3286c94ea7",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_screenshot.py": {
-    "mtime": 1781676014.8010993,
+    "mtime": 1781742682.2599416,
     "ast_hash": "adb54a320664565dfb92cbd101294a26",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_title.py": {
-    "mtime": 1781135063.0117555,
+    "mtime": 1781742682.2605093,
     "ast_hash": "0f23350619bcbda3f36d657477439443",
     "semantic_hash": ""
   },
   "src/juggle_graph_add.py": {
-    "mtime": 1781393823.192906,
+    "mtime": 1781742682.2634416,
     "ast_hash": "1c07ae2bc353ae0599ece03237865ff5",
     "semantic_hash": ""
   },
   "src/juggle_graph_load.py": {
-    "mtime": 1781391524.935111,
+    "mtime": 1781742682.2645955,
     "ast_hash": "c6ea3e652f830bab974805f3b2a20751",
     "semantic_hash": ""
   },
   "src/juggle_graph_upsert.py": {
-    "mtime": 1781391524.935735,
+    "mtime": 1781742682.2654126,
     "ast_hash": "bb17d75e690122340b4016c9188e14d2",
     "semantic_hash": ""
   },
   "tests/test_autopilot_state.py": {
-    "mtime": 1781162636.053408,
+    "mtime": 1781742682.2916543,
     "ast_hash": "9d325f1c3622cdb1d6b798b46ff6927a",
     "semantic_hash": ""
   },
   "tests/test_cockpit_footer_narrow.py": {
-    "mtime": 1781673258.6646369,
+    "mtime": 1781742682.299071,
     "ast_hash": "25252a655c1ef7e4986e880b595d7473",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_dag_load.py": {
-    "mtime": 1781391524.940227,
+    "mtime": 1781742682.2999327,
     "ast_hash": "2f8695bfdeebf44ea84645606e6aa5b5",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_keys.py": {
-    "mtime": 1781391524.9406226,
+    "mtime": 1781742682.3003347,
     "ast_hash": "a6601d75d0f2a5b01d5722c319ec0b4f",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_layout.py": {
-    "mtime": 1781391524.940983,
+    "mtime": 1781742682.300734,
     "ast_hash": "f4c55a5c070820c05fe7cd8aa5517b01",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_list.py": {
-    "mtime": 1781391524.9413314,
+    "mtime": 1781742682.3010836,
     "ast_hash": "745ba2cc3fab3947e09ba16a005e27fc",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_panel.py": {
-    "mtime": 1781588317.4010568,
+    "mtime": 1781742682.301689,
     "ast_hash": "05e6b888b75014eed490df6284799de7",
     "semantic_hash": ""
   },
   "tests/test_cockpit_graph_thread_label.py": {
-    "mtime": 1781391524.9424999,
+    "mtime": 1781742682.3020997,
     "ast_hash": "73a115cc8856a3c6fe6e05949515948f",
     "semantic_hash": ""
   },
   "tests/test_cockpit_row_trunc.py": {
-    "mtime": 1781160534.9331644,
+    "mtime": 1781742682.3067904,
     "ast_hash": "907306b45d2c3a285891ece008020dc4",
     "semantic_hash": ""
   },
   "tests/test_cockpit_version.py": {
-    "mtime": 1781135063.0119503,
+    "mtime": 1781742682.3086743,
     "ast_hash": "4aa44d9c47c8dcf8558d22ab2031868f",
     "semantic_hash": ""
   },
   "tests/test_db_topics.py": {
-    "mtime": 1781592098.843454,
+    "mtime": 1781742682.3136482,
     "ast_hash": "e1c6289bd66eca3c7e2ca6c9f6054528",
     "semantic_hash": ""
   },
   "tests/test_db_wal_pragmas.py": {
-    "mtime": 1781151831.1128564,
+    "mtime": 1781742682.3140168,
     "ast_hash": "1a0ccb93c2da1ae0e19a2154385d5c44",
     "semantic_hash": ""
   },
   "tests/test_graph_add_node.py": {
-    "mtime": 1781391524.944465,
+    "mtime": 1781742682.3168845,
     "ast_hash": "df6d0f20969824dcff38c675212aafc9",
     "semantic_hash": ""
   },
   "tests/test_graph_dispatch_send_task_db_path.py": {
-    "mtime": 1781391524.9468844,
+    "mtime": 1781742682.3189557,
     "ast_hash": "89482b1a3cea09a51a26576e6d43f458",
     "semantic_hash": ""
   },
   "tests/test_graph_spec_topics.py": {
-    "mtime": 1781391524.9492404,
+    "mtime": 1781742682.322091,
     "ast_hash": "ed3d5cba56370a339ded1961f458d29b",
     "semantic_hash": ""
   },
   "tests/test_migration_topics.py": {
-    "mtime": 1781391524.9528165,
+    "mtime": 1781742682.3333921,
     "ast_hash": "15b36878a46eaa72f4548ecd1834b588",
     "semantic_hash": ""
   },
   "tests/test_watchdog_main_repo.py": {
-    "mtime": 1781166481.074522,
+    "mtime": 1781742682.3537974,
     "ast_hash": "00fa08d53c0cd2de0bd3f5d629fd397b",
     "semantic_hash": ""
   },
   "tests/test_worktree_nesting.py": {
-    "mtime": 1781155971.1175592,
+    "mtime": 1781742682.354348,
     "ast_hash": "6e9e74b69df065012482cee0064a02b5",
     "semantic_hash": ""
   },
   "commands/project:add-task.md": {
-    "mtime": 1781391524.9200084,
+    "mtime": 1781742682.142555,
     "ast_hash": "3ad28fd3fa3af2bcaa8c9f1aa14de1c4",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-10-multi-project-autopilot-BRAINSTORM.md": {
-    "mtime": 1781150600.7193341,
+    "mtime": 1781742682.168415,
     "ast_hash": "3a99cdd46f0c65d38f03b54942008eeb",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-10-multi-project-autopilot-BRIEF.md": {
-    "mtime": 1781155452.889233,
+    "mtime": 1781742682.1687372,
     "ast_hash": "979b2f265ddb52012c90905be851007b",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-10-multi-project-autopilot.md": {
-    "mtime": 1781155452.88959,
+    "mtime": 1781742682.1690292,
     "ast_hash": "d4eeaf8ee2210752360709ce262d1ced",
     "semantic_hash": ""
   },
   "plan/2026-06-10-multi-project-autopilot.md": {
-    "mtime": 1781155452.8904123,
+    "mtime": 1781742682.228828,
     "ast_hash": "6fd55d2da1634574e1f0f0ec0b5e603a",
     "semantic_hash": ""
   },
   "reports/reflect-2026-06-08.md": {
-    "mtime": 1781132488.5617685,
+    "mtime": 1781742682.2323263,
     "ast_hash": "7191116d50d6858d60d56795e90df6fd",
     "semantic_hash": ""
   },
   "src/dbops/db_mirror.py": {
-    "mtime": 1781590058.988134,
+    "mtime": 1781742682.2412534,
     "ast_hash": "3f5cbbe06a2c148033fefc7254bb8042",
     "semantic_hash": ""
   },
   "src/dbops/db_topics_reconcile.py": {
-    "mtime": 1781592098.840727,
+    "mtime": 1781742682.241871,
     "ast_hash": "f87ecbb2865a48eefe1205efc75a1f96",
     "semantic_hash": ""
   },
   "src/dbops/graph_guards.py": {
-    "mtime": 1781592098.8409412,
+    "mtime": 1781742682.2422638,
     "ast_hash": "277ff202068e2176f46568b976db1ce2",
     "semantic_hash": ""
   },
   "src/dbops/runs.py": {
-    "mtime": 1781395273.7733111,
+    "mtime": 1781742682.2446685,
     "ast_hash": "dc1cc1dfc996d612c9252a8a8bcdadf1",
     "semantic_hash": ""
   },
   "src/dbops/schema_runs.py": {
-    "mtime": 1781395273.773523,
+    "mtime": 1781742682.2454724,
     "ast_hash": "96908845a854f3ece3071eda330d735d",
     "semantic_hash": ""
   },
   "src/juggle_cmd_agents_graph_topics.py": {
-    "mtime": 1781391524.9262033,
+    "mtime": 1781742682.250642,
     "ast_hash": "a9a5fe67f67e051ad1d02875678df6e4",
     "semantic_hash": ""
   },
   "src/juggle_cmd_runs.py": {
-    "mtime": 1781395273.7739959,
+    "mtime": 1781742682.2549078,
     "ast_hash": "1aff664fffec2341b6a2484d7f66bec4",
     "semantic_hash": ""
   },
   "src/juggle_graph_dispatch_topics.py": {
-    "mtime": 1781508136.0558767,
+    "mtime": 1781742682.2641194,
     "ast_hash": "2861c99b8cf702bedd440480b98f6d94",
     "semantic_hash": ""
   },
   "src/juggle_graph_scheduler.py": {
-    "mtime": 1781167484.172924,
+    "mtime": 1781742682.2648382,
     "ast_hash": "84e0b051ae96620baa3d1a9502359ce9",
     "semantic_hash": ""
   },
   "src/juggle_watchdog_singleton.py": {
-    "mtime": 1781597440.6477659,
+    "mtime": 1781742682.2794597,
     "ast_hash": "6b456fc83ae91344931aec9305ebdaff",
     "semantic_hash": ""
   },
   "src/vcs.py": {
-    "mtime": 1781395273.774154,
+    "mtime": 1781742682.282017,
     "ast_hash": "b9a8adbcfe3cbdccc4e5cc5f3532bf69",
     "semantic_hash": ""
   },
   "tests/conftest.py": {
-    "mtime": 1781588338.6453335,
+    "mtime": 1781742682.2843049,
     "ast_hash": "f429337330d6e3c4aede0a224169ca51",
     "semantic_hash": ""
   },
   "tests/test_agent_runs.py": {
-    "mtime": 1781391524.9383485,
+    "mtime": 1781742682.2892506,
     "ast_hash": "56ceaffbbd0f05c8c57a36b59c1c2ac6",
     "semantic_hash": ""
   },
   "tests/test_agent_runs_integration.py": {
-    "mtime": 1781391524.9387095,
+    "mtime": 1781742682.2897112,
     "ast_hash": "df266de6af480c2a7bba0ba366bc6ae4",
     "semantic_hash": ""
   },
   "tests/test_autopilot_guards.py": {
-    "mtime": 1781592098.8429108,
+    "mtime": 1781742682.2913635,
     "ast_hash": "645196fe80c69e2516823b35bfbcdb2b",
     "semantic_hash": ""
   },
   "tests/test_cmd_runs_cli.py": {
-    "mtime": 1781391524.9396083,
+    "mtime": 1781742682.2956276,
     "ast_hash": "058507504e6889c0393d91a5d1c943a7",
     "semantic_hash": ""
   },
   "tests/test_cockpit_footer_hotkeys.py": {
-    "mtime": 1781411885.5986614,
+    "mtime": 1781742682.2987125,
     "ast_hash": "0c969f14c1e854b1399e2e49f84664f1",
     "semantic_hash": ""
   },
   "tests/test_cockpit_project_arm.py": {
-    "mtime": 1781411885.5988522,
+    "mtime": 1781742682.306173,
     "ast_hash": "ddc2f65bd3981fd21b78367fb4663fb2",
     "semantic_hash": ""
   },
   "tests/test_db_isolation.py": {
-    "mtime": 1781588338.6454725,
+    "mtime": 1781742682.3114345,
     "ast_hash": "f8eb45c0f1d74ca5a7fa709153cb8098",
     "semantic_hash": ""
   },
   "tests/test_db_mirror.py": {
-    "mtime": 1781590058.9887516,
+    "mtime": 1781742682.3124313,
     "ast_hash": "f5f0d110563c00b99f4f5223703ef61f",
     "semantic_hash": ""
   },
   "tests/test_get_agent_busy_guard.py": {
-    "mtime": 1781509956.3957074,
+    "mtime": 1781742682.3156729,
     "ast_hash": "518c78d50512b37d26f748ef8f2767b2",
     "semantic_hash": ""
   },
   "tests/test_graph_guards.py": {
-    "mtime": 1781592098.844664,
+    "mtime": 1781742682.320131,
     "ast_hash": "bbcf257a456cf15e56d1d5f49e43de5d",
     "semantic_hash": ""
   },
   "tests/test_graph_hydration_topics.py": {
-    "mtime": 1781169777.758134,
+    "mtime": 1781742682.3205154,
     "ast_hash": "0f480429d8ad8cef69c09ff103b2c728",
     "semantic_hash": ""
   },
   "tests/test_graph_mirror.py": {
-    "mtime": 1781586031.4741912,
+    "mtime": 1781742682.321122,
     "ast_hash": "83d0a87eef936b980784cf0eb0d0c472",
     "semantic_hash": ""
   },
   "tests/test_graph_reconcile.py": {
-    "mtime": 1781592098.8449407,
+    "mtime": 1781742682.321464,
     "ast_hash": "996394e405051e6748de1bbceeae7d30",
     "semantic_hash": ""
   },
   "tests/test_graph_scheduler.py": {
-    "mtime": 1781167484.1730735,
+    "mtime": 1781742682.3218093,
     "ast_hash": "a3ef0dcb48295f2f393d2c1c562a5e46",
     "semantic_hash": ""
   },
   "tests/test_hooks_autopilot_multi.py": {
-    "mtime": 1781391524.9505265,
+    "mtime": 1781742682.3242755,
     "ast_hash": "4d18ec2dc3c13b57b43cb623df465696",
     "semantic_hash": ""
   },
   "tests/test_hooks_fail_open.py": {
-    "mtime": 1781199464.2284565,
+    "mtime": 1781742682.3248968,
     "ast_hash": "af22ad687d413c21ba8e750342bbbe20",
     "semantic_hash": ""
   },
   "tests/test_junk_thread_guard.py": {
-    "mtime": 1781504811.7116215,
+    "mtime": 1781742682.3314376,
     "ast_hash": "e838412dc62adca3bf5529ad8925a10e",
     "semantic_hash": ""
   },
   "tests/test_machinery_bugs_2026_06_11.py": {
-    "mtime": 1781592098.8452475,
+    "mtime": 1781742682.3325074,
     "ast_hash": "504b72b06a0e45ecbe7624ba33a29757",
     "semantic_hash": ""
   },
   "tests/test_migration_rename_node_to_task.py": {
-    "mtime": 1781391524.9524932,
+    "mtime": 1781742682.3330286,
     "ast_hash": "58badf04a9fd36d14cda80761fca8a52",
     "semantic_hash": ""
   },
   "tests/test_migrations_label_retire.py": {
-    "mtime": 1781588805.9629066,
+    "mtime": 1781742682.3337793,
     "ast_hash": "27da5632e8e8ee7d581d8bc28d971ec1",
     "semantic_hash": ""
   },
   "tests/test_no_auto_hindsight.py": {
-    "mtime": 1781409551.6309166,
+    "mtime": 1781742682.3342257,
     "ast_hash": "14ff4001eca382604d45a0e39a12811b",
     "semantic_hash": ""
   },
   "tests/test_runs_vcs_capture_restore.py": {
-    "mtime": 1781395273.774355,
+    "mtime": 1781742682.3422222,
     "ast_hash": "93f9805e078fd1131e0b07405c0fc089",
     "semantic_hash": ""
   },
   "tests/test_runs_vcs_migration.py": {
-    "mtime": 1781395273.7745342,
+    "mtime": 1781742682.342744,
     "ast_hash": "35b3ce1a495579087e9fdb66c8a5deb7",
     "semantic_hash": ""
   },
   "tests/test_slug_wheel.py": {
-    "mtime": 1781588805.963108,
+    "mtime": 1781742682.3445451,
     "ast_hash": "eef9e0a07d6349515bb4cf1d45c3e779",
     "semantic_hash": ""
   },
   "tests/test_thread_dedup.py": {
-    "mtime": 1781586031.4743865,
+    "mtime": 1781742682.345357,
     "ast_hash": "4f005fefea6408cf806ae20646fca1b3",
     "semantic_hash": ""
   },
   "tests/test_thread_label_recycle_regression.py": {
-    "mtime": 1781586013.374373,
+    "mtime": 1781742682.345866,
     "ast_hash": "10b0f8d6691a0c67ed7f3a8e6a5d9968",
     "semantic_hash": ""
   },
   "tests/test_topic_title.py": {
-    "mtime": 1781588317.5351727,
+    "mtime": 1781742682.351806,
     "ast_hash": "47aa0a88cbdc38b73badab93dc181cc7",
     "semantic_hash": ""
   },
   "tests/test_vcs.py": {
-    "mtime": 1781395273.7747147,
+    "mtime": 1781742682.3526223,
     "ast_hash": "f2f23426a739822e5b19a8b8c0907272",
     "semantic_hash": ""
   },
   "tests/test_verified_merged_sha.py": {
-    "mtime": 1781592098.8453903,
+    "mtime": 1781742682.3529036,
     "ast_hash": "9ec57ee095988d13bcee6a7945681555",
     "semantic_hash": ""
   },
   "tests/test_watchdog_child_start.py": {
-    "mtime": 1781597440.6489115,
+    "mtime": 1781742682.3531702,
     "ast_hash": "a6cb4263d8600d2f8ed1b84fc05cd418",
     "semantic_hash": ""
   },
   "tests/test_watchdog_daemon.py": {
-    "mtime": 1781492556.8481352,
+    "mtime": 1781742682.353448,
     "ast_hash": "7cbdba480677f9e953a9c05b604ec8bd",
     "semantic_hash": ""
   },
   "tests/test_watchdog_singleton.py": {
-    "mtime": 1781591102.087436,
+    "mtime": 1781742682.3541014,
     "ast_hash": "ee60b273d8d91cd25ed83e70bc99d7a7",
     "semantic_hash": ""
   },
   "tests/watchdog/test_bloat_stall_fix.py": {
-    "mtime": 1781505936.7900434,
+    "mtime": 1781742682.3613458,
     "ast_hash": "9803b5b12355ba70a837cd3dd2ff72fd",
     "semantic_hash": ""
   },
   "commands/runs.md": {
-    "mtime": 1781395273.772096,
+    "mtime": 1781742682.1463373,
     "ast_hash": "c9ba318d801a9d1e538317dad865521b",
     "semantic_hash": ""
   },
   "docs/incidents/2026-06-11-autopilot-graph-machinery.md": {
-    "mtime": 1781193888.3992422,
+    "mtime": 1781742682.162767,
     "ast_hash": "87aad07c760da6fe04816e0eb3688fa9",
     "semantic_hash": ""
   },
   "docs/incidents/2026-06-13-autopilot-shared-db-corruption.md": {
-    "mtime": 1781387301.5174422,
+    "mtime": 1781742682.1631207,
     "ast_hash": "d6ed19889a6cb87f0ba96ee9db9c8084",
     "semantic_hash": ""
   },
   "docs/incidents/2026-06-13-watchdog-g2-crashloop.md": {
-    "mtime": 1781411223.1868312,
+    "mtime": 1781742682.1634583,
     "ast_hash": "868d84209641eb896ce8e3dca03c4b56",
     "semantic_hash": ""
   },
   "docs/primitives.md": {
-    "mtime": 1781391524.9207613,
+    "mtime": 1781742682.1652088,
     "ast_hash": "e787bb464b2ddeebbcdebf020184a063",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-14-graph-mirrors-threads-plan.md": {
-    "mtime": 1781504683.2732344,
+    "mtime": 1781742682.16939,
     "ast_hash": "aac496d023be9f535aa1cf188cec9ac9",
     "semantic_hash": ""
   },
   "docs/superpowers/specs/2026-06-13-vcs-checkpoint-design.md": {
-    "mtime": 1781395273.7723145,
+    "mtime": 1781742682.173836,
     "ast_hash": "767bc8003f21e8e5e28bb8af8e52e39e",
     "semantic_hash": ""
   },
   "skills/runs/SKILL.md": {
-    "mtime": 1781395273.7725484,
+    "mtime": 1781742682.237273,
     "ast_hash": "3cd6b07510bc5ecab8cbed8c20924335",
     "semantic_hash": ""
   },
   "tests/test_cockpit_task_detail.py": {
-    "mtime": 1781673258.6649718,
+    "mtime": 1781742682.3083963,
     "ast_hash": "cbf1e4e847ce1ac11668196084bac6d9",
     "semantic_hash": ""
   },
   "src/juggle_integrate_testscope.py": {
-    "mtime": 1781682430.944241,
+    "mtime": 1781742682.2691867,
     "ast_hash": "a286af5c7cecec79c842a631d20626b0",
     "semantic_hash": ""
   },
   "tests/test_cockpit_watchdog_owner.py": {
-    "mtime": 1781597440.6484265,
+    "mtime": 1781742682.3091838,
     "ast_hash": "2b6e59dcb1da0176d7f982da997b3607",
     "semantic_hash": ""
   },
   "tests/test_integrate_phantom_sha.py": {
-    "mtime": 1781598598.6256475,
+    "mtime": 1781742682.3258538,
     "ast_hash": "60f9753a051e94931b5657365403b12f",
     "semantic_hash": ""
   },
   "tests/test_integrate_testscope.py": {
-    "mtime": 1781664069.6233757,
+    "mtime": 1781742682.3261395,
     "ast_hash": "1e9ad20cbf760a46867fbfa9b50c1eca",
     "semantic_hash": ""
   },
   "docs/incidents/2026-06-15-agent-bloat-stall-rca.md": {
-    "mtime": 1781503889.928456,
+    "mtime": 1781742682.1637669,
     "ast_hash": "f5a927de35f95edbf4ccf887df3a6430",
     "semantic_hash": ""
   },
   "docs/incidents/2026-06-16-integrate-phantom-merged-sha-rca.md": {
-    "mtime": 1781598598.6243303,
+    "mtime": 1781742682.1641283,
     "ast_hash": "566fca41ab79c37386b2e47b9f4afea6",
     "semantic_hash": ""
   },
   "scripts/install-graphify-hooks.sh": {
-    "mtime": 1781683355.9007738,
+    "mtime": 1781742682.2333546,
     "ast_hash": "d7e7aba75766924ed4ec82d000bc34bf",
     "semantic_hash": ""
   },
   "tests/test_graphify_hooks.sh": {
-    "mtime": 1781666752.252254,
+    "mtime": 1781742682.3229153,
     "ast_hash": "92fc49bc60671eab145452d17a536dc7",
     "semantic_hash": ""
   },
   "tests/test_cockpit_help_modal.py": {
-    "mtime": 1781667641.9420152,
+    "mtime": 1781742682.3025925,
     "ast_hash": "90a28f5ca622536861533938dcf8474f",
     "semantic_hash": ""
   },
   "tests/test_notification_no_truncation.py": {
-    "mtime": 1781669382.3520105,
+    "mtime": 1781742682.3345933,
     "ast_hash": "26a309fb0db64e3c7ad044d7cb679206",
     "semantic_hash": ""
   },
   "tests/test_cockpit_modal_dismiss.py": {
-    "mtime": 1781675947.6526897,
+    "mtime": 1781742682.304368,
     "ast_hash": "6c5ece152316fe96be724d922483ad0e",
     "semantic_hash": ""
   },
   "src/juggle_topic_summary.py": {
-    "mtime": 1781680995.3559163,
+    "mtime": 1781742682.2773013,
     "ast_hash": "6fcd5c1aa4bedd5747ff49296949e28a",
     "semantic_hash": ""
   },
   "tests/test_topic_summary.py": {
-    "mtime": 1781675947.6530254,
+    "mtime": 1781742682.351459,
     "ast_hash": "35187848233dfc41b754262c189e8436",
     "semantic_hash": ""
   },
   "src/juggle_cmd_db_flush.py": {
-    "mtime": 1781676014.799019,
+    "mtime": 1781742682.252674,
     "ast_hash": "24cd29ffc983be52b13262e0dfb0ccbd",
     "semantic_hash": ""
   },
   "src/juggle_cockpit_flush_status.py": {
-    "mtime": 1781676014.8000093,
+    "mtime": 1781742682.256187,
     "ast_hash": "349b543f5e49bf2f14fdcf24637c0b74",
     "semantic_hash": ""
   },
   "src/juggle_db_bootstrap.py": {
-    "mtime": 1781676014.8020532,
+    "mtime": 1781742682.2625449,
     "ast_hash": "3b889e0859d905984e7e759f9af403d6",
     "semantic_hash": ""
   },
   "src/juggle_db_connect.py": {
-    "mtime": 1781676014.8021953,
+    "mtime": 1781742682.262816,
     "ast_hash": "bba7379cc1dca1748499ffb691124eb8",
     "semantic_hash": ""
   },
   "src/juggle_db_path.py": {
-    "mtime": 1781676014.8023524,
+    "mtime": 1781742682.2630594,
     "ast_hash": "a4ac6ef3e355f93f1ff877aff4570f0a",
     "semantic_hash": ""
   },
   "tests/test_cockpit_flush_status.py": {
-    "mtime": 1781676014.8033574,
+    "mtime": 1781742682.2983732,
     "ast_hash": "f11bd8499d08e2d8cc778b3b3ff28066",
     "semantic_hash": ""
   },
   "tests/test_db_flush.py": {
-    "mtime": 1781676014.8035345,
+    "mtime": 1781742682.3108716,
     "ast_hash": "cf6beefdd096c82bdc527f032d7f7f77",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_bootstrap.py": {
-    "mtime": 1781676014.8036876,
+    "mtime": 1781742682.3466835,
     "ast_hash": "c2d20fac5d923a4f18cdaefee5af881c",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_db_path.py": {
-    "mtime": 1781676014.8039873,
+    "mtime": 1781742682.3469512,
     "ast_hash": "744f8db0a1a4f666c77b70841790f06d",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_doctor_resolver.py": {
-    "mtime": 1781676014.8041687,
+    "mtime": 1781742682.3475385,
     "ast_hash": "a8b79903bd07acf36d2c2542a2b2a619",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_init_integration.py": {
-    "mtime": 1781676014.804347,
+    "mtime": 1781742682.3478994,
     "ast_hash": "f9b9fb41d52b4f37efc8273b260db504",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_juggle_db_wire.py": {
-    "mtime": 1781676014.8045168,
+    "mtime": 1781742682.3481607,
     "ast_hash": "d524255478c631a2ce0f56e58a039e9d",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_settings.py": {
-    "mtime": 1781676014.804673,
+    "mtime": 1781742682.3484418,
     "ast_hash": "4f13fab7cc154e82e7f86cc4fe3cdf16",
     "semantic_hash": ""
   },
   "tests/test_tmpfs_splitbrain_guard.py": {
-    "mtime": 1781676014.8048198,
+    "mtime": 1781742682.3492935,
     "ast_hash": "6d6a244ce4d5c3ccbb965471aa910b83",
     "semantic_hash": ""
   },
   "tests/test_topic_detail_call_from_thread.py": {
-    "mtime": 1781677528.8936963,
+    "mtime": 1781742682.351189,
     "ast_hash": "ba591e3fd4aebf2cca6361b3a87fec64",
     "semantic_hash": ""
   },
   "docs/specs/2026-06-17-tmpfs-db-mode-plan.md": {
-    "mtime": 1781676014.7982416,
+    "mtime": 1781742682.1696842,
     "ast_hash": "2b88aaf2ea082b024dfddbb5444a2da0",
     "semantic_hash": ""
   },
   "tests/test_thread_dedup_scorer.py": {
-    "mtime": 1781678274.9119353,
+    "mtime": 1781742682.3456004,
     "ast_hash": "639232727c40499550ddbf249dc02258",
     "semantic_hash": ""
   },
   "config.example.md": {
-    "mtime": 1781679656.2227342,
+    "mtime": 1781742682.1486003,
     "ast_hash": "18ea35e0d79b5ce48f21635bfa449cf9",
     "semantic_hash": ""
   },
   "tests/test_parse_summary_markdown.py": {
-    "mtime": 1781680995.3568232,
+    "mtime": 1781742682.33731,
     "ast_hash": "94eea3bcfc24f25fadfdb683167fc9a6",
     "semantic_hash": ""
   },
   "scripts/git-merge-plugin-version.py": {
-    "mtime": 1781683355.8999062,
+    "mtime": 1781742682.2330875,
     "ast_hash": "4e7f2a98144ab68f90dcfbfb356785d4",
     "semantic_hash": ""
   },
   "tests/test_merge_driver.py": {
-    "mtime": 1781683355.9011214,
+    "mtime": 1781742682.332769,
     "ast_hash": "399287be1984a343e3b1df79ace773b2",
     "semantic_hash": ""
   },
   "tests/test_openrouter_fallback.py": {
-    "mtime": 1781734908.6455789,
+    "mtime": 1781742682.336524,
     "ast_hash": "92e327d6e61cdfea14713e883d3d626c",
     "semantic_hash": ""
   },
   "tests/test_selfheal_diagnosis.py": {
-    "mtime": 1781682702.2847002,
+    "mtime": 1781742682.3437152,
     "ast_hash": "5758f0f75786f3d71c0fd90a839efd49",
     "semantic_hash": ""
   },
   "projects/selfheal-diagnosis/plan/2026-06-17-selfheal-diagnosis-loop.md": {
-    "mtime": 1781682702.281252,
+    "mtime": 1781742682.2301824,
     "ast_hash": "d03e21bfcab980ea393a16832579b25a",
     "semantic_hash": ""
   },
-  ".claude/settings.local.json": {
-    "mtime": 1775953337.7248769,
-    "ast_hash": "872fe24593d58e6e973e4ad95d848716",
-    "semantic_hash": ""
-  },
   "tests/test_init_optional_key.py": {
-    "mtime": 1781735409.7299252,
+    "mtime": 1781742682.325167,
     "ast_hash": "79bbe7802222840afd892c9ab223adf9",
-    "semantic_hash": ""
-  },
-  "plan/2026-06-17-llm-gateway.md": {
-    "mtime": 1781735536.7523417,
-    "ast_hash": "39a9cccfc89fbe5203f02f61e43bb6ae",
-    "semantic_hash": ""
-  },
-  "research/2026-06-17-openrouter-fallback-facts.md": {
-    "mtime": 1781733295.7452168,
-    "ast_hash": "42f8181de086b29d92272840a6f10d14",
-    "semantic_hash": ""
-  },
-  "specs/2026-06-17-llm-gateway.md": {
-    "mtime": 1781735484.3353705,
-    "ast_hash": "7ec2c95623c5b48de58bf36bf37c1b01",
     "semantic_hash": ""
   }
 }


### PR DESCRIPTION
## What
Remove the obsolete `export _JUGGLE_TEST_DB="$HOME/.claude/juggle/juggle.db"` from the CLAUDE.md Testing setup block, and drop `_JUGGLE_TEST_DB` from the Required-env list.

## Why
Since the 2026-06-16 `tests/conftest.py` prod-DB isolation guard, setting `_JUGGLE_TEST_DB` to the production DB makes `juggle_cli_common.DB_PATH` resolve to prod at import time; any `get_db()` with no explicit path then opens `JuggleDB(prod)` and trips a fail-closed `TEST ISOLATION VIOLATION`. conftest now auto-isolates every test to a temp DB, so the export is obsolete and harmful. Hook tests still reach the shared DB via `juggle_hooks.DB_PATH` (`paths.data_dir` / `CLAUDE_PLUGIN_DATA`), independent of the removed var.

## Verification
- `uv run pytest tests/test_no_auto_hindsight.py -q` → 13 passed
- Full suite: 2268 passed (pre-existing `loc_gate` reds + an env-flaky cockpit nav smoke unrelated to this docs-only change)
- `doctor --dry-run` on a tmp DB: clean

Docs-only; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsjxvukcpuLQJ6QwPBf49M