### PR TITLE
feat(cockpit): auto-sort graph panel — active-over-done, recency, 60s snapshot, done-collapse

### DIFF
--- a/src/juggle_cockpit.py
+++ b/src/juggle_cockpit.py
@@ -928,8 +928,8 @@ class CockpitApp(GraphModeMixin, App):
         )
         if not dags:
             return
-        from juggle_cockpit_graph_panel import topological_order
-        flat = [(d, n) for d in dags for n in topological_order(d.tasks, d.edges)]
+        from juggle_cockpit_graph_layout import selectable_units
+        flat = [(d, n) for d in dags for n in selectable_units(d.tasks, d.edges)]
         sel = getattr(self, "_graph_sel", 0)
         pid = flat[sel][0].project_id if 0 <= sel < len(flat) else dags[0].project_id
         from juggle_cockpit_frontier_screen import FrontierScreen

--- a/src/juggle_cockpit_graph_dag.py
+++ b/src/juggle_cockpit_graph_dag.py
@@ -16,7 +16,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from juggle_cockpit_graph_order import (
+    ProjectActivity,
+    OrderCache,
+    order_projects,
+)
+
 ARMED_PROJECT_SETTING = "autopilot_armed_project"  # kept for compat reads
+
+# Live cockpit snapshot cache for the graph-panel order (throttle). Tests never
+# touch this — they inject their own OrderCache into order_projects directly.
+_ORDER_CACHE = OrderCache()
 
 
 @dataclass(frozen=True)
@@ -30,30 +40,101 @@ class GraphDag:
     project_name: "str | None" = None  # human project name for the panel header
 
 
-def _all_project_ids(conn) -> list[str]:
-    """All project ids that have graph work, ordered by last_active DESC then
-    alphabetically. Source is the unified ``nodes`` table (P8 Task 4.2)."""
+def gather_project_activity(conn) -> list[ProjectActivity]:
+    """Build ordering rows for every candidate project purely from the DB.
+
+    Candidates = active projects (projects table) ∪ any project referenced by a
+    root graph node (nodes table). Per project we derive:
+
+    - ``is_done`` — has >=1 root topic/task node AND none is non-verified (0 open
+      work). Matches ``frontier_visible``'s fully-done predicate.
+    - ``active_key`` — live agent-activity: max ``last_active_at`` over the
+      project's topics' dispatch-bound conversation nodes, floored by the
+      project's static ``last_active`` (ISO strings compare chronologically).
+    - ``done_key`` — completion recency: max ``verified_at`` over root nodes,
+      floored by ``last_active``.
+
+    Every read is fail-soft (degrades to '' / not-done) so a partial/legacy DB
+    never crashes the cockpit render.
+    """
     try:
         proj_rows = conn.execute(
-            "SELECT id FROM projects WHERE status='active' "
-            "ORDER BY last_active DESC, id"
+            "SELECT id, last_active FROM projects WHERE status='active'"
         ).fetchall()
-        listed = [r[0] for r in proj_rows]
-        extra: set[str] = set()
-        try:
-            for r in conn.execute(
-                "SELECT DISTINCT project_id FROM nodes "
-                "WHERE kind IN ('topic','task','research') AND parent_id IS NULL "
-                "AND project_id IS NOT NULL"
-            ).fetchall():
-                pid = r[0]
-                if pid and pid not in listed:
-                    extra.add(pid)
-        except Exception:
-            pass
-        return listed + sorted(extra)
     except Exception:
         return []
+    last_active: dict[str, str] = {r[0]: (r[1] or "") for r in proj_rows}
+    candidates: list[str] = list(last_active.keys())
+
+    try:
+        for r in conn.execute(
+            "SELECT DISTINCT project_id FROM nodes "
+            "WHERE kind IN ('topic','task','research') AND parent_id IS NULL "
+            "AND project_id IS NOT NULL"
+        ).fetchall():
+            pid = r[0]
+            if pid and pid not in last_active:
+                last_active[pid] = ""
+                candidates.append(pid)
+    except Exception:
+        pass
+
+    # Root-node aggregates: open (non-verified) count, total, max verified_at.
+    open_count: dict[str, int] = {}
+    root_total: dict[str, int] = {}
+    verified_max: dict[str, str] = {}
+    try:
+        for r in conn.execute(
+            "SELECT project_id, "
+            "SUM(CASE WHEN state != 'verified' THEN 1 ELSE 0 END) AS opn, "
+            "COUNT(*) AS total, MAX(COALESCE(verified_at,'')) AS vmax "
+            "FROM nodes "
+            "WHERE (kind='topic' OR (kind='task' AND parent_id IS NULL)) "
+            "AND project_id IS NOT NULL GROUP BY project_id"
+        ).fetchall():
+            open_count[r[0]] = r[1] or 0
+            root_total[r[0]] = r[2] or 0
+            verified_max[r[0]] = r[3] or ""
+    except Exception:
+        pass
+
+    # Live agent activity: max conversation last_active_at over the project's
+    # topics' dispatch-bound conversation nodes.
+    agent_ts: dict[str, str] = {}
+    try:
+        for r in conn.execute(
+            "SELECT t.project_id AS pid, MAX(COALESCE(c.last_active_at,'')) AS ts "
+            "FROM nodes t "
+            "JOIN node_edges de ON de.node_id = t.id AND de.kind='dispatch' "
+            "JOIN nodes c ON c.id = de.depends_on_id AND c.kind='conversation' "
+            "WHERE t.kind='topic' AND t.project_id IS NOT NULL GROUP BY t.project_id"
+        ).fetchall():
+            if r[0]:
+                agent_ts[r[0]] = r[1] or ""
+    except Exception:
+        pass
+
+    rows: list[ProjectActivity] = []
+    for pid in candidates:
+        la = last_active.get(pid, "")
+        is_done = root_total.get(pid, 0) > 0 and open_count.get(pid, 0) == 0
+        rows.append(
+            ProjectActivity(
+                id=pid,
+                is_done=is_done,
+                active_key=max(agent_ts.get(pid, ""), la),
+                done_key=max(verified_max.get(pid, ""), la),
+            )
+        )
+    return rows
+
+
+def _all_project_ids(conn) -> list[str]:
+    """All candidate project ids in fresh partitioned order (ACTIVE-above-DONE,
+    no throttle). Consumed only by ``load_graph_dags``."""
+    return order_projects(
+        gather_project_activity(conn), now=0.0, interval=0.0, cache=OrderCache()
+    )
 
 
 def _project_name(conn, pid: str) -> "str | None":
@@ -182,10 +263,34 @@ def _load_one(conn, pid: str) -> "GraphDag | None":
                     project_name=_project_name(conn, pid))
 
 
-def load_graph_dags(conn) -> list["GraphDag"]:
-    """Load topic-tier DAGs for ALL active projects with tasks, in priority order."""
+def _sort_interval() -> float:
+    """Snapshot throttle interval (secs) from cockpit.graph_sort_interval_seconds.
+    Fail-soft to the 60s default; <=0 means recompute every render."""
+    try:
+        from juggle_settings import get_settings
+
+        return float(get_settings()["cockpit"]["graph_sort_interval_seconds"])
+    except Exception:
+        return 60.0
+
+
+def load_graph_dags(conn, *, now: "float | None" = None) -> list["GraphDag"]:
+    """Load topic-tier DAGs for ALL active projects with tasks, in sort order.
+
+    ``now`` is the injected monotonic clock. When supplied (live cockpit) the
+    order is throttled through the module snapshot cache at the configured
+    interval so the panel does not reshuffle on every render. When ``None``
+    (tests / ad-hoc callers) the order is recomputed fresh with no throttle.
+    """
+    rows = gather_project_activity(conn)
+    if now is None:
+        ordered = order_projects(rows, now=0.0, interval=0.0, cache=OrderCache())
+    else:
+        ordered = order_projects(
+            rows, now=now, interval=_sort_interval(), cache=_ORDER_CACHE
+        )
     result = []
-    for pid in _all_project_ids(conn):
+    for pid in ordered:
         dag = _load_one(conn, pid)
         if dag is not None:
             result.append(dag)

--- a/src/juggle_cockpit_graph_dag.py
+++ b/src/juggle_cockpit_graph_dag.py
@@ -41,21 +41,13 @@ class GraphDag:
 
 
 def gather_project_activity(conn) -> list[ProjectActivity]:
-    """Build ordering rows for every candidate project purely from the DB.
+    """Ordering rows for every candidate project, derived purely from the DB.
 
-    Candidates = active projects (projects table) ∪ any project referenced by a
-    root graph node (nodes table). Per project we derive:
-
-    - ``is_done`` — has >=1 root topic/task node AND none is non-verified (0 open
-      work). Matches ``frontier_visible``'s fully-done predicate.
-    - ``active_key`` — live agent-activity: max ``last_active_at`` over the
-      project's topics' dispatch-bound conversation nodes, floored by the
-      project's static ``last_active`` (ISO strings compare chronologically).
-    - ``done_key`` — completion recency: max ``verified_at`` over root nodes,
-      floored by ``last_active``.
-
-    Every read is fail-soft (degrades to '' / not-done) so a partial/legacy DB
-    never crashes the cockpit render.
+    Candidates = active projects ∪ any project referenced by a root graph node.
+    ``is_done`` = has root nodes AND none non-verified. ``active_key`` = max
+    conversation ``last_active_at`` over the project's dispatch-bound topics,
+    floored by ``last_active``. ``done_key`` = max ``verified_at``, same floor
+    (ISO strings compare chronologically). Every read is fail-soft.
     """
     try:
         proj_rows = conn.execute(

--- a/src/juggle_cockpit_graph_dag.py
+++ b/src/juggle_cockpit_graph_dag.py
@@ -6,26 +6,20 @@ tables (P8 Task 4.2) — ONLY when graph mode is active
 module under its LOC budget. Read-only; degrades to None / [] on projects with no
 task nodes.
 
-Topic tier (R5/R9): DAG tasks are TOPICS, edges are derived topic deps, task
-counts per topic are attached as tasks_done/tasks_total on GraphTask. The flat
-task list per topic is stored in GraphDag.member_tasks for the detail modal.
-
-P7: per-project arming is removed — all projects with tasks are shown.
+Topic tier (R5/R9): DAG tasks are TOPICS, edges derived topic deps, per-topic
+task counts on GraphTask, member_tasks per topic for the detail modal. P7:
+per-project arming removed — all projects with tasks are shown.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from juggle_cockpit_graph_order import (
-    ProjectActivity,
-    OrderCache,
-    order_projects,
-)
+from juggle_cockpit_graph_order import ProjectActivity, OrderCache, order_projects
 
 ARMED_PROJECT_SETTING = "autopilot_armed_project"  # kept for compat reads
 
-# Live cockpit snapshot cache for the graph-panel order (throttle). Tests never
-# touch this — they inject their own OrderCache into order_projects directly.
+# Live cockpit snapshot cache for the graph-panel order (throttle). Tests inject
+# their own OrderCache into order_projects, so this global is never shared.
 _ORDER_CACHE = OrderCache()
 
 
@@ -38,6 +32,14 @@ class GraphDag:
     edges: list[tuple[str, str]]  # (topic_id, dep_topic_id)
     member_tasks: "dict | None" = field(default=None, compare=False)  # topic_id → list[dict]
     project_name: "str | None" = None  # human project name for the panel header
+
+
+def _norm_ts(ts: "str | None") -> str:
+    """Fold a stored timestamp to 'YYYY-MM-DD HH:MM' so keys compare
+    chronologically. The DB mixes isoformat ('T' separator, projects.last_active)
+    with strftime (space, conversation/verify); 'T'(0x54) > ' '(0x20) would
+    misorder same-minute rows. All UTC, so truncating to the minute is safe."""
+    return (ts or "").replace("T", " ")[:16]
 
 
 def gather_project_activity(conn) -> list[ProjectActivity]:
@@ -90,8 +92,7 @@ def gather_project_activity(conn) -> list[ProjectActivity]:
     except Exception:
         pass
 
-    # Live agent activity: max conversation last_active_at over the project's
-    # topics' dispatch-bound conversation nodes.
+    # Live agent activity: max conversation last_active_at over dispatch-bound topics.
     agent_ts: dict[str, str] = {}
     try:
         for r in conn.execute(
@@ -108,14 +109,18 @@ def gather_project_activity(conn) -> list[ProjectActivity]:
 
     rows: list[ProjectActivity] = []
     for pid in candidates:
-        la = last_active.get(pid, "")
+        la = _norm_ts(last_active.get(pid, ""))
+        agent = _norm_ts(agent_ts.get(pid, ""))
+        verified = _norm_ts(verified_max.get(pid, ""))
         is_done = root_total.get(pid, 0) > 0 and open_count.get(pid, 0) == 0
         rows.append(
             ProjectActivity(
                 id=pid,
                 is_done=is_done,
-                active_key=max(agent_ts.get(pid, ""), la),
-                done_key=max(verified_max.get(pid, ""), la),
+                # Agent-activity if any conversation ran, else last_active (spec
+                # FALLBACK not max — a recent creation ts never outranks active work).
+                active_key=agent or la,
+                done_key=max(verified, la),
             )
         )
     return rows

--- a/src/juggle_cockpit_graph_layout.py
+++ b/src/juggle_cockpit_graph_layout.py
@@ -99,6 +99,34 @@ def build_ranks(tasks: list[GraphTask], edges: list[tuple[str, str]]) -> list[Ra
 # ---------------------------------------------------------------------------
 
 
+def dag_is_done(tasks: list[GraphTask]) -> bool:
+    """A project's DAG is fully done when it has >=1 real (non-mirror) task and
+    every one is verified — the same predicate ``frontier_visible`` uses for its
+    'fully done' branch. Drives the cockpit done-collapse (spec 2026-07-03)."""
+    real = [n for n in tasks if not getattr(n, "is_mirror", False)]
+    return bool(real) and all(n.state == "verified" for n in real)
+
+
+def selectable_units(
+    tasks: list[GraphTask], edges: list[tuple[str, str]]
+) -> list[GraphTask]:
+    """Navigable units for one DAG — the single source of truth shared by the
+    panel render and the keyboard-selection sites.
+
+    A fully-done project collapses to a SINGLE representative unit (its last
+    real task in topological order) so it occupies exactly one selection slot,
+    matching the collapsed one-line render (selectable != expanded). An active
+    project keeps its frontier-visible list.
+    """
+    if dag_is_done(tasks):
+        flat: list[GraphTask] = []
+        for rank in build_ranks(tasks, edges):
+            flat.extend(rank.tasks)
+        real = [n for n in flat if not getattr(n, "is_mirror", False)]
+        return [real[-1]] if real else []
+    return frontier_visible(tasks, edges)[0]
+
+
 def frontier_visible(
     tasks: list[GraphTask],
     edges: list[tuple[str, str]],

--- a/src/juggle_cockpit_graph_mode.py
+++ b/src/juggle_cockpit_graph_mode.py
@@ -53,10 +53,10 @@ class GraphModeMixin:
             h = self.query_one("#graph-scroll").size.height or 20
         except Exception:
             w, h = 80, 20
-        # Selection iterates the VISIBLE (frontier-pruned) cells only, so clamp
-        # against the pruned count, not every task.
-        from juggle_cockpit_graph_layout import frontier_visible
-        total_tasks = sum(len(frontier_visible(d.tasks, d.edges)[0]) for d in dags)
+        # Selection iterates the navigable units (frontier-pruned cells, or one
+        # collapsed unit per done project), so clamp against that count.
+        from juggle_cockpit_graph_layout import selectable_units
+        total_tasks = sum(len(selectable_units(d.tasks, d.edges)) for d in dags)
         self._graph_sel = min(self._graph_sel, max(0, total_tasks - 1))
         return build_multi_graph_panel(
             dags=dags,
@@ -130,8 +130,8 @@ class GraphModeMixin:
             return
         # Concatenated VISIBLE list (same frontier-pruned order as the panel, so
         # the selection index resolves to the task the operator sees).
-        from juggle_cockpit_graph_layout import frontier_visible
-        flat = [n for d in dags for n in frontier_visible(d.tasks, d.edges)[0]]
+        from juggle_cockpit_graph_layout import selectable_units
+        flat = [n for d in dags for n in selectable_units(d.tasks, d.edges)]
         if not (0 <= self._graph_sel < len(flat)):
             return
         task_id = flat[self._graph_sel].id
@@ -213,8 +213,8 @@ class GraphModeMixin:
         )
         if not dags:
             return
-        from juggle_cockpit_graph_layout import frontier_visible
-        flat = [(d, n) for d in dags for n in frontier_visible(d.tasks, d.edges)[0]]
+        from juggle_cockpit_graph_layout import selectable_units
+        flat = [(d, n) for d in dags for n in selectable_units(d.tasks, d.edges)]
         sel = getattr(self, "_graph_sel", 0)
         pid = flat[sel][0].project_id if 0 <= sel < len(flat) else dags[0].project_id
         from juggle_cockpit_frontier_screen import FrontierScreen

--- a/src/juggle_cockpit_graph_order.py
+++ b/src/juggle_cockpit_graph_order.py
@@ -1,0 +1,109 @@
+"""Ordering + snapshot cache for the cockpit graph panel.
+
+Two responsibilities, both pure/testable:
+
+1. ``order_projects`` — the ordering MODEL. Two partitions, ACTIVE always above
+   DONE (INBOX pinned first). ACTIVE = a project with >=1 open (non-verified)
+   root topic/task, sorted by live agent-activity DESC (tiebreak id). DONE = zero
+   open work, sunk below all active projects, sorted by completion recency DESC.
+
+2. The snapshot THROTTLE. A caller-owned ``OrderCache`` freezes the computed
+   order for ``interval`` seconds so the panel does not reshuffle on every render.
+   Within the window the frozen order is returned verbatim — since-deleted
+   projects are dropped and brand-new ones are appended at the TAIL (so a new
+   project appears without reshuffling the rest). ``now`` is injected so tests
+   never sleep; ``interval<=0`` bypasses the cache (recompute every call).
+
+The DB-reading side (``gather_project_activity``) lives in
+juggle_cockpit_graph_dag so this module stays pure — no sqlite, no Rich, no time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+INBOX_ID = "INBOX"
+
+
+@dataclass(frozen=True)
+class ProjectActivity:
+    """One project's ordering inputs (pure — gathered from the DB elsewhere).
+
+    ``active_key`` / ``done_key`` are opaque comparable sort keys (ISO-timestamp
+    strings in production, ints in tests); DESC with an id tiebreak.
+    """
+
+    id: str
+    is_done: bool
+    active_key: object = ""
+    done_key: object = ""
+
+
+@dataclass
+class OrderCache:
+    """Mutable snapshot cell: the frozen order + the monotonic ts it was taken."""
+
+    ordered: "list[str] | None" = None
+    ts: "float | None" = None
+
+
+# Module-level default cache used by the live cockpit call site. Tests inject
+# their own OrderCache so they never touch this shared cell.
+_DEFAULT_CACHE = OrderCache()
+
+
+def _fresh_order(rows: "list[ProjectActivity]") -> list[str]:
+    """Recompute the full partitioned order from scratch.
+
+    INBOX first (if present), then ACTIVE (agent-activity DESC), then DONE
+    (completion-recency DESC). Ties broken by id ASC via a stable pre-sort.
+    """
+    inbox = [r for r in rows if r.id == INBOX_ID]
+    rest = [r for r in rows if r.id != INBOX_ID]
+
+    active = [r for r in rest if not r.is_done]
+    done = [r for r in rest if r.is_done]
+
+    # Stable sort trick: id ASC first, then the primary key DESC — equal primary
+    # keys keep the id-ascending order.
+    active.sort(key=lambda r: r.id)
+    active.sort(key=lambda r: r.active_key, reverse=True)
+    done.sort(key=lambda r: r.id)
+    done.sort(key=lambda r: r.done_key, reverse=True)
+
+    return [r.id for r in inbox] + [r.id for r in active] + [r.id for r in done]
+
+
+def order_projects(
+    rows: "list[ProjectActivity]",
+    *,
+    now: float,
+    interval: float,
+    cache: "OrderCache | None" = None,
+) -> list[str]:
+    """Return the ordered project-id list, honoring the snapshot throttle.
+
+    Within ``interval`` of the last snapshot the frozen order is reused (deleted
+    projects dropped, new ones appended at the tail). Otherwise the order is
+    recomputed and the snapshot reset to ``now``. ``interval<=0`` always
+    recomputes. ``now`` is the injected clock (time.monotonic() at the call
+    site).
+    """
+    cache = cache if cache is not None else _DEFAULT_CACHE
+
+    fresh_within_window = (
+        interval > 0
+        and cache.ordered is not None
+        and cache.ts is not None
+        and (now - cache.ts) < interval
+    )
+    if fresh_within_window:
+        current = {r.id for r in rows}
+        frozen = [pid for pid in cache.ordered if pid in current]
+        seen = set(frozen)
+        appended = [r.id for r in rows if r.id not in seen]
+        return frozen + appended
+
+    ordered = _fresh_order(rows)
+    cache.ordered = list(ordered)
+    cache.ts = now
+    return ordered

--- a/src/juggle_cockpit_graph_panel.py
+++ b/src/juggle_cockpit_graph_panel.py
@@ -20,7 +20,7 @@ from rich.table import Table
 from rich.text import Text
 from rich.style import Style
 
-from juggle_cockpit_graph_layout import GraphTask, frontier_visible
+from juggle_cockpit_graph_layout import GraphTask, dag_is_done, frontier_visible, selectable_units
 from juggle_cockpit_legend import graph_inline_legend, TASK_STATE_GLYPHS
 
 # Per-project row/section renderers extracted to juggle_cockpit_graph_rows
@@ -74,6 +74,18 @@ def build_graph_panel(
 
     inner_w_hdr = max(8, width - 4)
     real_tasks = [n for n in tasks if not getattr(n, "is_mirror", False)]
+
+    # Done-collapse (spec 2026-07-03 §3): a fully-verified project renders as a
+    # single '✅ <name> — N/N done' line, matching the multi-panel section.
+    if dag_is_done(tasks):
+        from juggle_cockpit_graph_rows import done_summary_line
+
+        units = selectable_units(tasks, edges)
+        selected = bool(units) and 0 <= selection < len(units)
+        summary = done_summary_line(project_id, project_name, real_tasks, selected=selected)
+        legend = Text(graph_inline_legend(), style=Style(dim=True))
+        return Panel(_Group(summary, legend), title=title, border_style="cyan")
+
     header = _section_header(project_id, project_name, real_tasks, inner_w_hdr, edges)
 
     flat = topological_order(tasks, edges)
@@ -174,9 +186,10 @@ def build_multi_graph_panel(
             project_name=getattr(d, "project_name", None), scroll=scroll,
         )
     inner_w = max(8, width - 4)
-    # Selection iterates the VISIBLE (frontier-pruned) list only, concatenated
-    # across the stacked dags — same order the sections render.
-    flat_all = [n for d in dags for n in frontier_visible(d.tasks, d.edges)[0]]
+    # Selection iterates the navigable units per dag — the frontier-pruned list
+    # for an active project, or the single collapsed unit for a done one — in the
+    # same order (and count) the sections render.
+    flat_all = [n for d in dags for n in selectable_units(d.tasks, d.edges)]
     sel_id = flat_all[selection].id if 0 <= selection < len(flat_all) else None
     parts: list = []
     for i, d in enumerate(dags):

--- a/src/juggle_cockpit_graph_rows.py
+++ b/src/juggle_cockpit_graph_rows.py
@@ -13,7 +13,13 @@ from rich.table import Table
 from rich.text import Text
 from rich.style import Style
 
-from juggle_cockpit_graph_layout import GraphTask, build_ranks, frontier_visible
+from juggle_cockpit_graph_layout import (
+    GraphTask,
+    build_ranks,
+    dag_is_done,
+    frontier_visible,
+    selectable_units,
+)
 from juggle_cockpit_legend import (
     TASK_STATE_GLYPHS,
     GRAPH_READY_SUFFIX,
@@ -159,6 +165,23 @@ def _flat_selectable(tasks: list[GraphTask]) -> list[GraphTask]:
     return topological_order(tasks, [])
 
 
+def done_summary_line(
+    project_id: str,
+    project_name: str | None,
+    real_tasks: list[GraphTask],
+    *,
+    selected: bool = False,
+) -> Text:
+    """Collapsed one-line summary for a fully-done project (spec 2026-07-03 §3):
+    '✅ <ProjectName> — N/N done'. Reclaims the vertical space its full DAG used;
+    ``selected`` reverses it so it still shows as the cursor target."""
+    done_glyph = TASK_STATE_GLYPHS["verified"]
+    label = project_name or project_id
+    n = len(real_tasks)
+    text = f"{done_glyph} {label} — {n}/{n} done"
+    return Text(text, style=Style(color="green", dim=not selected, reverse=selected))
+
+
 def _graph_section(
     project_id: str,
     tasks: list[GraphTask],
@@ -175,6 +198,15 @@ def _graph_section(
         return [Text(f"{label}: no graph tasks yet", style=Style(dim=True))]
 
     real_tasks = [n for n in tasks if not getattr(n, "is_mirror", False)]
+
+    # Done-collapse: a fully-verified project renders as a single summary line
+    # instead of its full DAG. Its one selectable unit (selectable_units) is the
+    # cursor target, so highlight the line when that unit is selected.
+    if dag_is_done(tasks):
+        units = selectable_units(tasks, edges)
+        selected = bool(units) and sel_id == units[0].id
+        return [done_summary_line(project_id, project_name, real_tasks, selected=selected)]
+
     header = _section_header(project_id, project_name, real_tasks, inner_w, edges)
 
     flat = topological_order(tasks, edges)

--- a/src/juggle_cockpit_model.py
+++ b/src/juggle_cockpit_model.py
@@ -396,7 +396,7 @@ def snapshot(db, *, load_graph_dag: bool = False) -> CockpitState:
     except Exception:
         notifications = []
 
-    _dags = _load_graph_dags(conn) if load_graph_dag else []
+    _dags = _load_graph_dags(conn, now=time.monotonic()) if load_graph_dag else []
     graph_dag, graph_dags = (_dags[0], _dags) if _dags else (None, None)
 
     from juggle_cockpit_topic_cap import cap_topics, resolve_max_topics  # topics-pane cap

--- a/src/juggle_settings.py
+++ b/src/juggle_settings.py
@@ -75,10 +75,7 @@ DEFAULTS: dict = {
         "notification_ratio": 30,
         "bell": True,
         "desktop_notifications": False,
-        # Graph-panel auto-sort throttle: the ordered project list is frozen for
-        # this many seconds so the panel does not reshuffle on every render.
-        # <=0 recomputes the order every render (test bypass).
-        "graph_sort_interval_seconds": 60,
+        "graph_sort_interval_seconds": 60,  # graph sort throttle secs; <=0=every render
     },
     # Paths
     "paths": {

--- a/src/juggle_settings.py
+++ b/src/juggle_settings.py
@@ -75,6 +75,10 @@ DEFAULTS: dict = {
         "notification_ratio": 30,
         "bell": True,
         "desktop_notifications": False,
+        # Graph-panel auto-sort throttle: the ordered project list is frozen for
+        # this many seconds so the panel does not reshuffle on every render.
+        # <=0 recomputes the order every render (test bypass).
+        "graph_sort_interval_seconds": 60,
     },
     # Paths
     "paths": {

--- a/tests/test_cockpit_graph_order.py
+++ b/tests/test_cockpit_graph_order.py
@@ -1,0 +1,136 @@
+"""Unit tests for the cockpit graph-panel ordering + snapshot cache.
+
+Feature: auto-sort the cockpit graph panel so recently-worked projects rise and
+finished ones sink and collapse (spec 2026-07-03-cockpit-graph-sort).
+
+Pure tests only — inject ``now`` and the cache, feed ``ProjectActivity`` rows.
+No live TUI, no sleep, no DB.
+"""
+from __future__ import annotations
+
+import pytest
+
+from juggle_cockpit_graph_order import (
+    ProjectActivity,
+    OrderCache,
+    order_projects,
+)
+
+
+def PA(pid, *, done=False, active=0, done_key=0):
+    return ProjectActivity(id=pid, is_done=done, active_key=active, done_key=done_key)
+
+
+# --------------------------------------------------------------------------
+# Fresh-order partitioning (interval<=0 => always recompute)
+# --------------------------------------------------------------------------
+
+def test_active_projects_sort_above_done():
+    rows = [PA("D", done=True, done_key=999), PA("A", active=1)]
+    assert order_projects(rows, now=0, interval=0, cache=OrderCache()) == ["A", "D"]
+
+
+def test_recency_within_active_partition_desc():
+    rows = [PA("low", active=1), PA("high", active=9), PA("mid", active=5)]
+    assert order_projects(rows, now=0, interval=0, cache=OrderCache()) == [
+        "high",
+        "mid",
+        "low",
+    ]
+
+
+def test_done_partition_sorts_by_completion_recency_desc():
+    rows = [PA("old", done=True, done_key=1), PA("new", done=True, done_key=9)]
+    assert order_projects(rows, now=0, interval=0, cache=OrderCache()) == ["new", "old"]
+
+
+def test_tiebreak_by_id_within_active():
+    rows = [PA("b", active=5), PA("a", active=5)]
+    assert order_projects(rows, now=0, interval=0, cache=OrderCache()) == ["a", "b"]
+
+
+def test_inbox_pinned_first_even_when_done_and_stale():
+    rows = [
+        PA("INBOX", done=True, active=0, done_key=0),
+        PA("A", active=9),
+        PA("D", done=True, done_key=9),
+    ]
+    assert order_projects(rows, now=0, interval=0, cache=OrderCache()) == [
+        "INBOX",
+        "A",
+        "D",
+    ]
+
+
+# --------------------------------------------------------------------------
+# Snapshot cache / throttle
+# --------------------------------------------------------------------------
+
+def test_order_frozen_within_interval_even_when_activity_changes():
+    cache = OrderCache()
+    first = [PA("A", active=1), PA("B", active=2)]
+    assert order_projects(first, now=0, interval=60, cache=cache) == ["B", "A"]
+
+    # A becomes the most-active project mid-window; order must NOT reshuffle.
+    churned = [PA("A", active=100), PA("B", active=2)]
+    assert order_projects(churned, now=30, interval=60, cache=cache) == ["B", "A"]
+
+
+def test_new_project_appended_at_tail_without_reshuffle_mid_window():
+    cache = OrderCache()
+    order_projects([PA("A", active=1), PA("B", active=2)], now=0, interval=60, cache=cache)
+
+    with_new = [PA("A", active=1), PA("B", active=2), PA("C", active=999)]
+    assert order_projects(with_new, now=10, interval=60, cache=cache) == ["B", "A", "C"]
+
+
+def test_deleted_project_dropped_from_frozen_order_mid_window():
+    cache = OrderCache()
+    order_projects(
+        [PA("A", active=1), PA("B", active=2), PA("C", active=3)],
+        now=0,
+        interval=60,
+        cache=cache,
+    )
+    remaining = [PA("A", active=1), PA("C", active=3)]
+    assert order_projects(remaining, now=5, interval=60, cache=cache) == ["C", "A"]
+
+
+def test_interval_honored_recomputes_after_window_expires():
+    cache = OrderCache()
+    order_projects([PA("A", active=1), PA("B", active=2)], now=0, interval=60, cache=cache)
+    churned = [PA("A", active=100), PA("B", active=2)]
+    # now - snapshot_ts == interval => window expired => recompute.
+    assert order_projects(churned, now=60, interval=60, cache=cache) == ["A", "B"]
+
+
+def test_interval_non_positive_recomputes_every_call():
+    cache = OrderCache()
+    order_projects([PA("A", active=1), PA("B", active=2)], now=0, interval=0, cache=cache)
+    churned = [PA("A", active=100), PA("B", active=2)]
+    assert order_projects(churned, now=0, interval=0, cache=cache) == ["A", "B"]
+
+
+# --------------------------------------------------------------------------
+# Regression pin
+# --------------------------------------------------------------------------
+
+def test_regression_cockpit_graph_autosort_active_over_done_and_frozen():
+    """Pin: cockpit-graph-autosort (2026-07-03) — a freshly-worked ACTIVE
+    project must sit above a finished one, and the order stays frozen within the
+    snapshot interval so the panel does not reshuffle on every render."""
+    cache = OrderCache()
+    rows = [
+        PA("done-old", done=True, done_key=5),
+        PA("active-hot", active=10),
+        PA("done-new", done=True, done_key=50),
+    ]
+    first = order_projects(rows, now=100, interval=60, cache=cache)
+    assert first == ["active-hot", "done-new", "done-old"]
+    # Within the window: churn activity, order must not move.
+    churn = [
+        PA("done-old", done=True, done_key=5),
+        PA("active-hot", active=0),
+        PA("done-new", done=True, done_key=50),
+    ]
+    assert order_projects(churn, now=120, interval=60, cache=cache) == first

--- a/tests/test_cockpit_graph_order.py
+++ b/tests/test_cockpit_graph_order.py
@@ -8,7 +8,6 @@ No live TUI, no sleep, no DB.
 """
 from __future__ import annotations
 
-import pytest
 
 from juggle_cockpit_graph_order import (
     ProjectActivity,

--- a/tests/test_cockpit_graph_order_db.py
+++ b/tests/test_cockpit_graph_order_db.py
@@ -1,0 +1,93 @@
+"""DB-level tests for cockpit graph ordering: gather_project_activity derives
+active/done partition + activity keys from the real nodes tables, and
+load_graph_dags renders projects in that order.
+
+Feature spec: 2026-07-03-cockpit-graph-sort. A project with open (non-verified)
+root topics is ACTIVE and sorts above a fully-verified DONE project.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from juggle_db import JuggleDB  # noqa: E402
+from dbops import db_graph as g, db_topics as tp  # noqa: E402
+from juggle_cockpit_graph_dag import (  # noqa: E402
+    gather_project_activity,
+    load_graph_dags,
+)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "juggle.db"))
+    d.init_db()
+    return d
+
+
+def _project(db, pid, last_active):
+    with db._connect() as conn:
+        conn.execute(
+            "INSERT INTO projects(id,name,status,created_at,last_active) "
+            "VALUES(?,?,?,?,?)",
+            (pid, pid, "active", last_active, last_active),
+        )
+        conn.commit()
+
+
+def _set_topic_state(db, tid, state):
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE nodes SET state=? WHERE id=? AND kind='topic'", (state, tid)
+        )
+        conn.commit()
+
+
+def _seed_active_and_done(db):
+    """ACT: topic still running (open work). DONE: topic verified (no open work)."""
+    _project(db, "ACT", "2026-07-03 10:00")
+    _project(db, "DONE", "2026-07-03 09:00")
+    tp.create_topic(db, topic_id="act1", project_id="ACT", title="active topic")
+    tp.create_topic(db, topic_id="done1", project_id="DONE", title="done topic")
+    g.create_task(db, task_id="at1", project_id="ACT", title="at1", prompt="p")
+    g.create_task(db, task_id="dt1", project_id="DONE", title="dt1", prompt="p")
+    g.set_task_topic(db, "at1", "act1")
+    g.set_task_topic(db, "dt1", "done1")
+    _set_topic_state(db, "act1", "running")
+    _set_topic_state(db, "done1", "verified")
+
+
+def test_gather_marks_done_when_all_root_topics_verified(db):
+    _seed_active_and_done(db)
+    rows = {r.id: r for r in gather_project_activity(db._connect())}
+    assert rows["ACT"].is_done is False
+    assert rows["DONE"].is_done is True
+
+
+def test_load_graph_dags_sorts_active_before_done(db):
+    """PIN: cockpit-graph-autosort (2026-07-03) — a finished project must sink
+    below one with open work in the rendered DAG order."""
+    _seed_active_and_done(db)
+    dags = load_graph_dags(db._connect())
+    pids = [d.project_id for d in dags]
+    assert pids.index("ACT") < pids.index("DONE")
+
+
+def test_load_graph_dags_orders_active_by_recency(db):
+    """Two active projects: the more-recently-active one renders first."""
+    _project(db, "OLD", "2026-07-01 08:00")
+    _project(db, "NEW", "2026-07-03 20:00")
+    for pid in ("OLD", "NEW"):
+        tp.create_topic(db, topic_id=f"{pid}-t", project_id=pid, title="t")
+        g.create_task(db, task_id=f"{pid}-x", project_id=pid, title="x", prompt="p")
+        g.set_task_topic(db, f"{pid}-x", f"{pid}-t")
+        _set_topic_state(db, f"{pid}-t", "running")
+    dags = load_graph_dags(db._connect())
+    pids = [d.project_id for d in dags]
+    assert pids.index("NEW") < pids.index("OLD")

--- a/tests/test_cockpit_graph_order_db.py
+++ b/tests/test_cockpit_graph_order_db.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest

--- a/tests/test_cockpit_graph_order_db.py
+++ b/tests/test_cockpit_graph_order_db.py
@@ -90,3 +90,23 @@ def test_load_graph_dags_orders_active_by_recency(db):
     dags = load_graph_dags(db._connect())
     pids = [d.project_id for d in dags]
     assert pids.index("NEW") < pids.index("OLD")
+
+
+def test_active_key_normalizes_mixed_timestamp_formats(db):
+    """PIN: cockpit-graph-autosort (2026-07-03) — projects.last_active is stored
+    isoformat ('2026-07-03T09:00...', a 'T' separator) while conversation/verify
+    timestamps use a space. Raw string compare puts 'T' (0x54) after ' ' (0x20),
+    so a chronologically EARLIER T-format project would wrongly outrank a LATER
+    space-format one at the same date. gather_project_activity must normalize so
+    the later project ranks first regardless of source format."""
+    # EARLY is 09:00 in isoformat (T); LATE is 10:00 space-format — LATE is later.
+    _project(db, "EARLY", "2026-07-03T09:00:00+00:00")
+    _project(db, "LATE", "2026-07-03 10:00")
+    for pid in ("EARLY", "LATE"):
+        tp.create_topic(db, topic_id=f"{pid}-t", project_id=pid, title="t")
+        g.create_task(db, task_id=f"{pid}-x", project_id=pid, title="x", prompt="p")
+        g.set_task_topic(db, f"{pid}-x", f"{pid}-t")
+        _set_topic_state(db, f"{pid}-t", "running")
+    dags = load_graph_dags(db._connect())
+    pids = [d.project_id for d in dags]
+    assert pids.index("LATE") < pids.index("EARLY")

--- a/tests/test_cockpit_graph_panel.py
+++ b/tests/test_cockpit_graph_panel.py
@@ -331,3 +331,43 @@ async def test_graph_header_shows_project_name_in_app(tmp_path):
         buf = io.StringIO()
         Console(width=158, file=buf, no_color=True).print(panel)
         assert "Juggle Claude Code Plugin" in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Done-project collapse (spec 2026-07-03-cockpit-graph-sort §3)
+# ---------------------------------------------------------------------------
+
+
+def test_done_project_renders_collapsed_one_line_summary():
+    """PIN: cockpit-graph-autosort (2026-07-03) — a fully-verified project must
+    collapse to a single '✅ <name> — N/N done' line instead of its full DAG,
+    reclaiming vertical space; an active sibling still renders its full grid."""
+    from juggle_cockpit_graph_dag import GraphDag
+    from juggle_cockpit_graph_panel import build_multi_graph_panel
+
+    dags = [
+        GraphDag(
+            project_id="ACT",
+            tasks=[GraphTask("act-run", "Build", "running", thread_id="t1")],
+            edges=[], member_tasks={}, project_name="Active One",
+        ),
+        GraphDag(
+            project_id="DONE",
+            tasks=[
+                GraphTask("zzdone1", "Alpha", "verified"),
+                GraphTask("zzdone2", "Beta", "verified"),
+            ],
+            edges=[("zzdone2", "zzdone1")], member_tasks={}, project_name="Done Two",
+        ),
+    ]
+    panel = build_multi_graph_panel(
+        dags=dags, selection=0, unread=0, width=120, height=40, pan_offset=0
+    )
+    out = _text(panel, width=120)
+    # Collapsed summary line present…
+    assert "✅ Done Two — 2/2 done" in out
+    # …and the done project's individual task cells are NOT rendered.
+    assert "zzdone1" not in out
+    assert "zzdone2" not in out
+    # The active sibling still renders its grid cell.
+    assert "act-run" in out


### PR DESCRIPTION
## Cockpit graph panel auto-sort

Auto-sorts the cockpit graph panel so recently-worked projects rise and finished ones stop hogging the viewport (topic [GL], brainstormed + spec'd with the user).

### Behavior
- **Active-over-done partition:** projects with open work sort above fully-done ones. Blocked/failed projects stay in the ACTIVE partition (partition = has-open-work, not live-agent).
- **Recency:** active projects sorted by live agent-activity (fallback: `last_active`); done projects by completion recency. **INBOX pinned first**, pre-partition.
- **60s snapshot throttle:** order frozen for `cockpit.graph_sort_interval_seconds` (default 60, `<=0` = every render) so it doesn't flash. Injected clock → lock-free, testable without sleeps.
- **Done-project collapse:** a fully-verified project renders as `✅ <name> — N/N done` instead of its full DAG, reclaiming space, but stays selectable via the shared `selectable_units` seam. Collapse is decoupled from the snapshot so finished projects reclaim space immediately while keeping their slot until the next reorder.

### Refactor-first
New focused module `src/juggle_cockpit_graph_order.py` holds the pure `order_projects(...)` + snapshot cache; `juggle_cockpit_graph_dag.py` just calls it.

### DA fix (caught + pinned during review)
The DB mixes `isoformat()` (`T`) and `strftime` (space) timestamps — a raw string compare mis-orders same-minute rows (`T`=0x54 > space=0x20). Added `_norm_ts` and switched `active_key` to the spec's fallback semantics.

### Verification
- Full suite **3675 passed, 7 skipped**; `doctor --dry-run` clean; `cockpit --smoke` **7/7 viewports PASS**; `--out` visually confirms collapse; ruff + LOC gate green.
- New tests: `test_cockpit_graph_order.py`, `test_cockpit_graph_order_db.py`, collapse render test. Spec + DA written to vault (`2026-07-03-cockpit-graph-sort.md`).

### ⚠️ Reviewer note
`graph_dag.py` (300) and `juggle_settings.py` (460) now sit **exactly** at their LOC budgets — trim comments before extending either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
