### PR TITLE
Loop entity V1 — recurring scheduled agent work (loops table, delivered terminal, watchdog firing)

### DIFF
--- a/commands/schedule:create.md
+++ b/commands/schedule:create.md
@@ -1,0 +1,96 @@
+---
+description: Create a scheduled task — routes OS-schedule (script on a timer) vs loop (a recurring Juggle work topic), confirms the type, then creates it
+allowed-tools: Bash, Read, Write
+---
+
+# /juggle:schedule:create
+
+Unified schedule-create router. From a natural-language requirement it decides
+between the **two** kinds of recurring thing Juggle can schedule, confirms the
+choice with a plan card, then creates it. V1 loops are **single-topic** only.
+
+## Arguments
+
+`$ARGUMENTS` — natural language, e.g.:
+- `run ~/github/trading-edge/scripts/news-ingest every 15 minutes` → **OS schedule**
+- `every morning at 8, research overnight AI news and write me a digest` → **loop**
+
+## Step 1 — Understand intent, then ROUTE (OS-schedule XOR loop)
+
+Classify the requirement into exactly ONE type:
+
+- **OS SCHEDULE** — runs an existing **script/binary** on a timer. No Juggle agent,
+  no work topic, no completion contract. Keywords: a concrete file path, "run
+  <script>", "cron", ingestion/backup/sync jobs. → hand off to `/juggle:schedule`
+  (the launchd/systemd/cron backend is UNCHANGED — do not reimplement it here).
+
+- **LOOP** — a recurring **unit of agent work** (a topic) that Juggle dispatches,
+  drives to completion, and re-fires each cadence. Keywords: "research/summarize/
+  draft/review …", "every day/week produce …", anything that needs an agent rather
+  than a fixed script. → build a single-topic loop template (Step 2).
+
+If ambiguous, ASK the user which they mean — misroute is cheap to avoid here and
+expensive to unwind later.
+
+## Step 2 (LOOP only) — Build the single-topic template
+
+Compose ONE topic with one or more member tasks that **all share the same
+`(role, model, delivery)`**. The deterministic validator
+(`juggle_loop_template_validator`) REJECTS a mixed-signature or multi-topic
+template — do not try to work around it; a differing signature means it is not a V1
+loop.
+
+- **role** — `researcher` (read-only, no worktree), `coder`, or `planner`.
+- **delivery** — `deliver` (non-merge work: a digest/report/notification whose proof
+  is a `verify_cmd`/attestation, NO merge) or `merge` (lands to main, verified⟺merged).
+  A "write me a digest / notify me" loop is almost always `deliver`.
+- **cadence** — `every 15m` / `every 6h` / `daily at 08:00`.
+
+Write the template to a temp JSON file:
+
+```json
+{
+  "topics": [
+    {
+      "id": "overnight-ai-digest",
+      "title": "Overnight AI news digest",
+      "objective": "Research overnight AI news and write a digest",
+      "delivery": "deliver",
+      "tasks": [
+        {"id": "research", "title": "Research + write digest",
+         "prompt": "Search for AI news from the last 24h and write a concise digest.",
+         "role": "researcher", "model": null, "verify_cmd": null, "deps": []}
+      ]
+    }
+  ]
+}
+```
+
+## Step 3 — Confirm the plan card (states the chosen type EXPLICITLY)
+
+Before creating anything, show the user a plan card that NAMES the routed type so a
+misroute is overridable:
+
+```
+Type:     LOOP  (recurring agent work topic)   ← or:  OS SCHEDULE (script on a timer)
+Cadence:  daily at 08:00
+Topic:    overnight-ai-digest — Overnight AI news digest
+Role:     researcher      Delivery: deliver (no merge)
+```
+
+Wait for confirmation. If the user says it's the other type, re-route.
+
+## Step 4 — Create
+
+- **OS SCHEDULE** → follow `/juggle:schedule` verbatim (launchd/systemd/cron).
+- **LOOP** → transactional, atomic create:
+
+```bash
+juggle loop create --template /tmp/loop-template.json --cadence "daily at 08:00" \
+  --name "Overnight AI digest"
+```
+
+The create is ONE DB transaction — the `kind='loop'` project, the topic graph, and
+the loop row (with `next_run`) are written all-or-nothing. If any step fails the
+whole create rolls back (no orphan project/loop/nodes). The loop project is
+excluded from P-slots/arming; the watchdog fires it on cadence (Phase 5).

--- a/scripts/loc_gate.py
+++ b/scripts/loc_gate.py
@@ -57,7 +57,7 @@ GRANDFATHERED: dict[str, int] = {
     "scripts/talkback": 415,
     "src/schedules/dogfood.py": 407,  # +1 `import os` — speedup-tier M1 (2026-06-21)
     "src/juggle_cmd_research.py": 398,
-    "src/juggle_graph_dispatch.py": 410,  # +1 fix-topic-unblock-sweep: convergent per-tick unblock_topic_dependents call, kept alongside the raising recompute (R4 pin) — irreducible loop wiring (2026-07-04)
+    "src/juggle_graph_dispatch.py": 355,  # 410->355 loop-entity Phase 2: extracted the flat-task fallback to juggle_graph_dispatch_flat.py (freed budget for per-node _resolve_dispatch_role); reserves headroom for the Phase-2 role-resolution helper (2026-07-04)
     "src/juggle_watchdog_daemon.py": 487,  # +3 fix-paste-submit-detect: irreducible tick wiring for the paste-submit fast-sweep (import + secs_since kwarg + unsubmitted branch); bulk extracted to juggle_paste_submit.py (2026-07-03)
     "src/dbops/db_topics.py": 367,  # +1 irl-repair T4: re-export set_topic_fail_envelope from db_topics_marking (2026-07-03)
     "src/juggle_context.py": 345,

--- a/src/dbops/db_node_machine.py
+++ b/src/dbops/db_node_machine.py
@@ -46,6 +46,12 @@ _NODE_TRANSITIONS: dict[tuple[str, str], str] = {
     ("integrating", "integrate_fail"):  "failed-integration",
     ("integrating", "verify_fail"):     "failed-verify",
     ("integrating", "archive"):         "archived",
+    # deliver_ok (loop-entity V1 Phase 3, 2026-07-04): delivery='deliver' topics
+    # complete to 'delivered' WITHOUT the merged_sha gate — non-merge work (proof
+    # is a verify_cmd/attestation, not a landed sha). db_topics.topic_transition
+    # only runs the merged_sha gate on the 'verified' target, so 'delivered' never
+    # sets merged_sha (verified⟺merged stays the sole merge gate).
+    ("integrating", "deliver_ok"):      "delivered",
     # integrated-unlanded (async-land, SPEC §5.1/§5.2): tests-green and submitted
     # to an async land queue (Sapling/git-pr) but not yet an ancestor of trunk.
     # Sits BELOW verified — must never set merged_sha (graph_guards.topic_is_merged
@@ -56,6 +62,12 @@ _NODE_TRANSITIONS: dict[tuple[str, str], str] = {
     # verified
     ("verified", "g1_pass"):  "done",
     ("verified", "archive"):  "archived",
+    # delivered — non-merge success terminal (Phase 3). Mirrors verified's exits
+    # (g1_pass→done, archive→archived, reopen→open) so a delivered node is never a
+    # dead-end and add-task can reopen a delivered topic. NEVER sets merged_sha.
+    ("delivered", "g1_pass"): "done",
+    ("delivered", "archive"): "archived",
+    ("delivered", "reopen"):  "open",
     # failure terminals → reload resurrects
     ("failed-exec",         "reload"):  "open",
     ("failed-exec",         "archive"): "archived",
@@ -115,6 +127,7 @@ _KIND_LEGAL: dict[str, frozenset[str]] = {
         "integrate_start", "exec_fail",
         "integrate_ok", "integrate_fail", "verify_fail",
         "integrate_submitted", "land_confirmed", "land_fail",
+        "deliver_ok",
         "g1_pass", "reopen", "cancel",
     }),
     "research": frozenset({

--- a/src/dbops/db_topics.py
+++ b/src/dbops/db_topics.py
@@ -42,7 +42,7 @@ _TOPIC_SELECT = (
     "(SELECT depends_on_id FROM node_edges WHERE node_id=nodes.id AND kind='dispatch' "
     "LIMIT 1) AS thread_id, merged_sha, submitted_rev, pending_merged_sha, "
     "pending_merged_repo, handoff, diffstat, plan_path, spec_path, worktree_branch, "
-    f"main_repo_path, fail_envelope, verified_at, priority, created_at, updated_at FROM nodes WHERE {_TOPIC_ONLY}"
+    f"main_repo_path, fail_envelope, verified_at, priority, delivery, created_at, updated_at FROM nodes WHERE {_TOPIC_ONLY}"
 )
 
 

--- a/src/dbops/db_topics_marking.py
+++ b/src/dbops/db_topics_marking.py
@@ -116,7 +116,8 @@ def mark_topic_completion(db, topic_id, *, integrate_ok, verify_ok=True,
     topic = get_topic(db, topic_id)
     if topic is None:
         raise ValueError(f"graph topic not found: {topic_id!r}")
-    if integrate_ok and topic["state"] in ("verified", "integrated-unlanded"):
+    if integrate_ok and topic["state"] in ("verified", "integrated-unlanded",
+                                            "delivered"):
         return topic["state"]
     if topic["state"] not in _ADVANCE_TO_INTEGRATING:
         raise ValueError(
@@ -134,6 +135,12 @@ def mark_topic_completion(db, topic_id, *, integrate_ok, verify_ok=True,
     if submitted_rev:
         set_topic_submitted_rev(db, topic_id, submitted_rev)
         return topic_transition(db, topic_id, "integrate_submitted")
+    # Completion contract fork (loop-entity V1 Phase 3): delivery='deliver' topics
+    # complete to 'delivered' with NO merge — the merged_sha gate (fired only on
+    # the 'verified' target) is bypassed by construction. delivery='merge' (the
+    # default) keeps the integrate_ok→verified edge verbatim.
+    if (topic.get("delivery") or "merge") == "deliver":
+        return topic_transition(db, topic_id, "deliver_ok")
     return topic_transition(db, topic_id, "integrate_ok")
 
 

--- a/src/dbops/event_kinds.py
+++ b/src/dbops/event_kinds.py
@@ -39,6 +39,15 @@ RUNNING_ORPHAN = "running_orphan"
 # tick rolled up learnings written since the last per-project watermark — the
 # orchestrator triages them (commands/start.md). Routing derived, not manual.
 LEARNINGS_ROLLUP = "learnings_rollup"
+# loop-entity V1 Phase 5 (2026-07-04): a scheduled loop's iteration failed (any
+# failed/wedged iteration — NOT only a breaker trip) or the failure circuit-breaker
+# tripped and paused the loop. A loop failure is machinery / unclassifiable /
+# exhausted-repairs, which per the CLAUDE.md triage ladder pushes the orchestrator
+# IMMEDIATELY (not a watchdog-only playbook). The loop is a NEW event SOURCE triaged
+# under the CURRENT self-heal/triage implementation — routing is derived (no manual
+# handled_by), same mechanism as MACHINERY_ERROR / REPAIR_EXHAUSTED / LEARNINGS_ROLLUP.
+LOOP_ITERATION_FAILED = "loop_iteration_failed"
+LOOP_PAUSED = "loop_paused"
 
 ALL_KINDS = frozenset(
     {
@@ -61,6 +70,8 @@ ALL_KINDS = frozenset(
         DISPATCH_FAILED,
         RUNNING_ORPHAN,
         LEARNINGS_ROLLUP,
+        LOOP_ITERATION_FAILED,
+        LOOP_PAUSED,
     }
 )
 
@@ -100,6 +111,10 @@ HANDLED_BY = {
     # gl-rollup: the orchestrator reads/triages the rolled-up learnings — the
     # judgment step of the triage ladder. Derived routing (no manual handled_by).
     LEARNINGS_ROLLUP: "orchestrator",
+    # loop-entity Phase 5: a loop iteration failure / breaker pause is machinery
+    # judgment — the orchestrator triages it immediately (derived routing).
+    LOOP_ITERATION_FAILED: "orchestrator",
+    LOOP_PAUSED: "orchestrator",
 }
 
 # handled_by values that are pushed (to a human or the orchestrator) rather

--- a/src/dbops/loops.py
+++ b/src/dbops/loops.py
@@ -84,6 +84,62 @@ class LoopsMixin:
                 raise ValueError(f"loop not found: {loop_id!r}")
             return row[0]
 
+    def advance_next_run_cas(self, loop_id: str, *, expected, new: str) -> int:
+        """Compare-and-swap the loop's ``next_run`` (mirrors dbops.state_write.cas_state).
+
+        ``UPDATE ... WHERE next_run IS <expected>`` — advances the timer to ``new``
+        ONLY if it still reads ``expected``. Returns the rowcount (0 = lost race /
+        already advanced this window). Phase 5 advances next_run BEFORE instantiating
+        the iteration so a crash between fire and advance can never double-fire
+        (critique §Axis-7b): the winning tick owns the window; any concurrent/retried
+        tick reads the moved next_run and loses the CAS (rowcount 0)."""
+        with self._connect() as conn:
+            if expected is None:
+                cur = conn.execute(
+                    "UPDATE loops SET next_run = ?, updated_at = ? "
+                    "WHERE id = ? AND next_run IS NULL",
+                    (new, _now(), loop_id),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE loops SET next_run = ?, updated_at = ? "
+                    "WHERE id = ? AND next_run = ?",
+                    (new, _now(), loop_id, expected),
+                )
+            conn.commit()
+            return cur.rowcount
+
+    def bump_consecutive_failures(self, loop_id: str) -> int:
+        """Atomically increment and return the loop's consecutive-failure count
+        (UPDATE...RETURNING, same pattern as advance_run_seq). The circuit-breaker
+        trips when this reaches ``max_consecutive_failures``."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "UPDATE loops SET consecutive_failures = consecutive_failures + 1, "
+                "updated_at = ? WHERE id = ? RETURNING consecutive_failures",
+                (_now(), loop_id),
+            ).fetchone()
+            conn.commit()
+            if row is None:
+                raise ValueError(f"loop not found: {loop_id!r}")
+            return row[0]
+
+    def reset_consecutive_failures(self, loop_id: str) -> None:
+        """Zero the consecutive-failure counter (a good iteration clears it — the
+        breaker trips on CONSECUTIVE failures only)."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE loops SET consecutive_failures = 0, updated_at = ? WHERE id = ?",
+                (_now(), loop_id),
+            )
+            conn.commit()
+
+    def pause_loop(self, loop_id: str) -> None:
+        """Set status='paused' (circuit-breaker trip). A paused loop is inert —
+        list_active_loops excludes it, so fire_due_loops never fires it again until
+        the orchestrator resumes it."""
+        self.set_loop_status(loop_id, "paused")
+
     def set_loop_status(self, loop_id: str, status: str) -> None:
         with self._connect() as conn:
             conn.execute(

--- a/src/dbops/loops.py
+++ b/src/dbops/loops.py
@@ -1,0 +1,101 @@
+"""dbops.loops — Loop entity CRUD + atomic run-seq mixin (loop-entity V1, P1).
+
+Owns: create/get/list/status/stamp on the ``loops`` table and the atomic
+``advance_run_seq`` counter (the id-namespace that keeps a re-fired iteration's
+node ids from colliding with the guarded-upsert refusal).
+Must not own: firing/scheduling logic (Phase 5), template validation (Phase 4).
+
+Mirrors dbops.projects.ProjectsMixin shape (label-wheel allocation, thin
+per-method connections). advance_run_seq mirrors migration_seq.reserve_next's
+single-statement UPDATE...RETURNING under SQLite's own file lock — safe across
+concurrent connections/processes against the same DB file.
+"""
+from __future__ import annotations
+
+from dbops.schema import _now
+
+
+class LoopsMixin:
+    """Mixin for loop-entity CRUD and the atomic run-seq counter."""
+
+    def _next_loop_label(self, used: set) -> str:
+        i = 1
+        while True:
+            label = f"L{i}"
+            if label not in used:
+                return label
+            i += 1
+
+    def create_loop(
+        self,
+        project_id: str,
+        cadence: str = "",
+        *,
+        next_run: str | None = None,
+        thread_id: str | None = None,
+        max_consecutive_failures: int = 3,
+    ) -> str:
+        """Insert a new loop (status='active', run_seq=0) and return its L-label."""
+        with self._connect() as conn:
+            used = {r[0] for r in conn.execute("SELECT id FROM loops").fetchall()}
+            loop_id = self._next_loop_label(used)
+            now = _now()
+            conn.execute(
+                "INSERT INTO loops (id, project_id, thread_id, cadence, status, "
+                "run_seq, next_run, last_run_at, consecutive_failures, "
+                "max_consecutive_failures, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',0,?,NULL,0,?,?,?)",
+                (loop_id, project_id, thread_id, cadence, next_run,
+                 max_consecutive_failures, now, now),
+            )
+            conn.commit()
+        return loop_id
+
+    def get_loop(self, loop_id: str) -> dict | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM loops WHERE id = ?", (loop_id,)
+            ).fetchone()
+            return dict(row) if row else None
+
+    def list_active_loops(self) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM loops WHERE status = 'active' ORDER BY created_at"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def advance_run_seq(self, loop_id: str) -> int:
+        """Atomically bump and return the loop's run_seq (strictly increasing).
+
+        Single-statement UPDATE...RETURNING under SQLite's file lock — safe
+        across concurrent callers (mirrors migration_seq.reserve_next). Returns
+        the NEW value; the caller namespaces iteration node ids as
+        ``<L#>-r<run_seq>-<topic>`` so re-fires never collide with the
+        guarded-upsert refusal (juggle_graph_load.py)."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "UPDATE loops SET run_seq = run_seq + 1, updated_at = ? "
+                "WHERE id = ? RETURNING run_seq",
+                (_now(), loop_id),
+            ).fetchone()
+            conn.commit()
+            if row is None:
+                raise ValueError(f"loop not found: {loop_id!r}")
+            return row[0]
+
+    def set_loop_status(self, loop_id: str, status: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE loops SET status = ?, updated_at = ? WHERE id = ?",
+                (status, _now(), loop_id),
+            )
+            conn.commit()
+
+    def stamp_last_run(self, loop_id: str, ts: str | None = None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE loops SET last_run_at = ?, updated_at = ? WHERE id = ?",
+                (ts or _now(), _now(), loop_id),
+            )
+            conn.commit()

--- a/src/dbops/migration_72_node_role_delivery.py
+++ b/src/dbops/migration_72_node_role_delivery.py
@@ -1,0 +1,44 @@
+"""Migration 72 (loop-entity V1, Phase 1) — additive per-node role/delivery and
+per-project kind columns.
+
+Loop entity needs three discriminators, every one defaulting to CURRENT
+behavior so existing graphs/projects are byte-for-byte unchanged:
+  - nodes.role     TEXT DEFAULT 'coder'   — dispatch role (Phase 2 reads it;
+                                            legacy nodes still dispatch coder).
+  - nodes.delivery TEXT DEFAULT 'merge'   — completion contract (Phase 3 branches
+                                            on it; 'merge' → verified as today).
+  - projects.kind  TEXT DEFAULT 'project' — 'loop' projects self-schedule and are
+                                            excluded from P-slots (Phase 4).
+
+ADDITIVE only, idempotent, presence-guarded, fail-soft (matches Migration 70/71).
+Never rebuilds the table. Reserved via `juggle migration next` (2026-07-04).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+_log = logging.getLogger(__name__)
+
+
+def migrate_72_node_role_delivery(conn: sqlite3.Connection) -> None:
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    try:
+        if "nodes" in tables:
+            ncols = {r[1] for r in conn.execute("PRAGMA table_info(nodes)")}
+            if "role" not in ncols:
+                conn.execute(
+                    "ALTER TABLE nodes ADD COLUMN role TEXT NOT NULL DEFAULT 'coder'")
+            if "delivery" not in ncols:
+                conn.execute(
+                    "ALTER TABLE nodes ADD COLUMN delivery TEXT NOT NULL DEFAULT 'merge'")
+        if "projects" in tables:
+            pcols = {r[1] for r in conn.execute("PRAGMA table_info(projects)")}
+            if "kind" not in pcols:
+                conn.execute(
+                    "ALTER TABLE projects ADD COLUMN kind TEXT NOT NULL DEFAULT 'project'")
+        conn.commit()
+        _log.info("Migration 72: nodes.role/delivery + projects.kind ensured")
+    except sqlite3.OperationalError as e:  # fail-soft (additive convention)
+        _log.warning("Migration 72 (node_role_delivery) skipped: %s", e)

--- a/src/dbops/migration_73_loops.py
+++ b/src/dbops/migration_73_loops.py
@@ -1,0 +1,31 @@
+"""Migration 73 (loop-entity V1, Phase 1) — additive ``loops`` table.
+
+Installs the loop entity (recurring, self-scheduling project driver) plus its
+run-seq id-namespace counter and the Phase-5 circuit-breaker columns (reserved
+here per plan open-question #2 so Phase 5 adds no migration). DDL lives in
+dbops.schema_loops.CREATE_LOOPS so fresh `db init` and this migrate path stay in
+lockstep.
+
+ADDITIVE only, idempotent (CREATE TABLE IF NOT EXISTS), fail-soft (matches
+Migration 70/71). Never rebuilds the table. Reserved via `juggle migration next`
+(2026-07-04).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from dbops.schema_loops import CREATE_LOOPS, CREATE_LOOPS_INDEXES
+
+_log = logging.getLogger(__name__)
+
+
+def migrate_73_loops(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute(CREATE_LOOPS)
+        for idx in CREATE_LOOPS_INDEXES:
+            conn.execute(idx)
+        conn.commit()
+        _log.info("Migration 73: loops table ensured")
+    except sqlite3.OperationalError as e:  # fail-soft (additive convention)
+        _log.warning("Migration 73 (loops) skipped: %s", e)

--- a/src/dbops/migrations_tail.py
+++ b/src/dbops/migrations_tail.py
@@ -53,3 +53,11 @@ def apply_tail_migrations(conn: sqlite3.Connection) -> None:
     # columns — nodes.reintegrate_attempts/last_attempt/pid.
     from dbops.migration_71_reintegrate_backoff import migrate_71_reintegrate_backoff
     migrate_71_reintegrate_backoff(conn)
+
+    # Migration 72 (loop-entity V1 Phase 1): nodes.role/delivery + projects.kind.
+    from dbops.migration_72_node_role_delivery import migrate_72_node_role_delivery
+    migrate_72_node_role_delivery(conn)
+
+    # Migration 73 (loop-entity V1 Phase 1): loops table + run-seq/breaker columns.
+    from dbops.migration_73_loops import migrate_73_loops
+    migrate_73_loops(conn)

--- a/src/dbops/projects.py
+++ b/src/dbops/projects.py
@@ -181,7 +181,7 @@ class ProjectsMixin:
     def get_dirty_projects(self) -> list[dict]:
         with self._connect() as conn:
             rows = conn.execute(
-                "SELECT * FROM projects WHERE profile_dirty=1 AND status NOT IN ('archived','closed') AND id != 'INBOX'",
+                "SELECT * FROM projects WHERE profile_dirty=1 AND status NOT IN ('archived','closed') AND id != 'INBOX' AND kind != 'loop'",
             ).fetchall()
         return [dict(r) for r in rows]
 

--- a/src/dbops/projects.py
+++ b/src/dbops/projects.py
@@ -49,10 +49,16 @@ class ProjectsMixin:
 
     def list_projects(self, include_archived: bool = False) -> list[dict]:
         with self._connect() as conn:
+            # kind='loop' projects self-schedule (Phase 4/5) and must NOT surface as
+            # armable P-slot projects (critique §11 bullet 2) — excluded from the
+            # default (arming/arm-modal/project-list) feed. include_archived=True is
+            # the "give me everything" path (doctor migrate / graph show) and keeps
+            # loops so they still get migrated.
             q = (
                 "SELECT * FROM projects"
                 if include_archived
-                else "SELECT * FROM projects WHERE status NOT IN ('archived', 'closed')"
+                else "SELECT * FROM projects WHERE status NOT IN ('archived', 'closed') "
+                "AND kind != 'loop'"
             )
             return [dict(r) for r in conn.execute(q).fetchall()]
 
@@ -61,7 +67,7 @@ class ProjectsMixin:
         with self._connect() as conn:
             rows = conn.execute(
                 "SELECT * FROM projects WHERE status NOT IN ('archived', 'closed') "
-                "AND id != 'INBOX' ORDER BY created_at"
+                "AND id != 'INBOX' AND kind != 'loop' ORDER BY created_at"
             ).fetchall()
             return [dict(r) for r in rows]
 

--- a/src/dbops/schema.py
+++ b/src/dbops/schema.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import os
-import string
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -216,7 +215,11 @@ CREATE TABLE IF NOT EXISTS projects (
   last_active      TEXT NOT NULL,
   match_profile    TEXT DEFAULT '',
   profile_synth_at TEXT,
-  profile_dirty    INTEGER NOT NULL DEFAULT 0
+  profile_dirty    INTEGER NOT NULL DEFAULT 0,
+  -- Loop-entity V1 (Phase 1): 'project' (default, unchanged) vs 'loop'. Migration
+  -- 72 appends it to already-migrated DBs; a 'loop' project self-schedules and is
+  -- excluded from P-slots (Phase 4).
+  kind             TEXT NOT NULL DEFAULT 'project'
 );
 """
 
@@ -237,6 +240,13 @@ from dbops.schema_graph import (  # noqa: E402,F401
     CREATE_GRAPH_EDGES,
     CREATE_GRAPH_TASKS,
     CREATE_GRAPH_TOPICS,
+)
+
+# loops table DDL lives in dbops.schema_loops (architecture gate). Re-exported so
+# ``from dbops.schema import CREATE_LOOPS`` keeps working.
+from dbops.schema_loops import (  # noqa: E402,F401
+    CREATE_LOOPS,
+    CREATE_LOOPS_INDEXES,
 )
 
 # agent_runs ledger DDL lives in dbops.schema_runs (architecture gate). Re-

--- a/src/dbops/schema_loops.py
+++ b/src/dbops/schema_loops.py
@@ -1,0 +1,39 @@
+"""dbops.schema_loops — DDL constant for the loops table (loop-entity V1, P1).
+
+Owns: the CREATE TABLE string for the loop entity (a recurring, self-scheduling
+project driver). Extracted into its own single-purpose module (mirrors
+schema_nodes / schema_graph) so dbops.schema stays inside the architecture LOC
+gate. Re-exported from dbops.schema for back-compat.
+
+Every column defaults to inert/current behavior:
+  - status                   'active'  (a paused loop never fires)
+  - run_seq                  0         (id-namespace counter, bumped at fire time)
+  - consecutive_failures     0         circuit-breaker counter (Phase 5)
+  - max_consecutive_failures 3         breaker threshold (Phase 5)
+
+run_seq + the breaker columns are reserved HERE (Phase 1) per the plan's
+open-question #2 so Phase 5 adds no further migration.
+"""
+from __future__ import annotations
+
+CREATE_LOOPS = """
+CREATE TABLE IF NOT EXISTS loops (
+  id                       TEXT PRIMARY KEY,
+  project_id               TEXT NOT NULL REFERENCES projects(id),
+  thread_id                TEXT,
+  cadence                  TEXT NOT NULL DEFAULT '',
+  status                   TEXT NOT NULL DEFAULT 'active',
+  run_seq                  INTEGER NOT NULL DEFAULT 0,
+  next_run                 TEXT,
+  last_run_at              TEXT,
+  consecutive_failures     INTEGER NOT NULL DEFAULT 0,
+  max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+  created_at               TEXT NOT NULL,
+  updated_at               TEXT NOT NULL
+);
+"""
+
+CREATE_LOOPS_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_loops_status ON loops(status);",
+    "CREATE INDEX IF NOT EXISTS idx_loops_project ON loops(project_id);",
+]

--- a/src/dbops/schema_nodes.py
+++ b/src/dbops/schema_nodes.py
@@ -92,6 +92,16 @@ CREATE TABLE IF NOT EXISTS nodes (
   -- between fresh and migrated DBs.
   fail_envelope           TEXT,
 
+  -- Loop-entity V1 (Phase 1): nodes.role (dispatch role, default 'coder') and
+  -- nodes.delivery (completion contract, default 'merge') are ADDED BY Migration
+  -- 72 — deliberately NOT carried here. The CREATE_NODES DDL is frozen at
+  -- Migration 63 (fail_envelope): every later column (66/67/70/71 + these) is
+  -- migration-only, so a fresh DB acquires them via the SAME ALTER-append path as
+  -- an already-migrated DB (init_db always runs run_migrations). Adding them here
+  -- would place them mid-table on fresh DBs but end-of-table on migrated DBs,
+  -- diverging `SELECT *` column order. Both default to CURRENT behavior so
+  -- existing graphs are byte-for-byte unchanged.
+
   -- Kind discriminator (P8 M2): ONE wide table holds every kind (NOT split
   -- per-kind). This CHECK enforces that verify_cmd — the execution-only column —
   -- is carried ONLY by a kind='task' node, so a conversation/topic/research/

--- a/src/dbops/terminal_states.py
+++ b/src/dbops/terminal_states.py
@@ -32,9 +32,14 @@ from pathlib import Path
 
 # ── Atomic building blocks ──────────────────────────────────────────────────────
 ACTIVE_STATES = frozenset({"dispatching", "running", "integrating"})
-# Phase 3 adds "delivered" to TERMINAL_SUCCESS_STATES — every consumer composed
-# from it (TASK_TERMINAL_STATES, TERMINAL_STATES, …) then inherits it for free.
-TERMINAL_SUCCESS_STATES = frozenset({"verified"})
+# Two success-terminals (Phase 3, 2026-07-04): 'verified' (delivery='merge',
+# backed by a merged_sha ancestor of main) and 'delivered' (delivery='deliver',
+# non-merge work whose proof is a verify_cmd/attestation — NO merged_sha). Every
+# consumer composed from this set (TASK_TERMINAL_STATES, TERMINAL_STATES, …)
+# inherits 'delivered' for free. The merged_sha GATE (graph_guards.topic_is_merged
+# / db_topics._verified_allowed) reads the column directly and is DELIBERATELY not
+# composed from this set, so verified⟺merged stays verified-only.
+TERMINAL_SUCCESS_STATES = frozenset({"verified", "delivered"})
 ASYNC_PENDING_STATES = frozenset({"integrated-unlanded"})
 DONE_ROLLUP_STATES = frozenset({"done"})
 CANCELLED_STATES = frozenset({"cancelled"})
@@ -178,9 +183,11 @@ VERIFIED_SQL_LITERAL_SITES: dict[str, tuple[str, ...]] = {
     "juggle_add_node.py": (
         "\"WHERE e.node_id=? AND e.kind='dep' AND d.state != 'verified' LIMIT 1\",",
     ),
+    # Phase 3 (2026-07-04): both rollup literals gained 'delivered' so a delivered
+    # topic/task counts as done (open-count) — deliver loops never read incomplete.
     "juggle_cockpit_graph_dag.py": (
-        "\"SUM(CASE WHEN state IN ('verified','cancelled') THEN 1 ELSE 0 END) AS done, \"",
-        "\"SUM(CASE WHEN state NOT IN ('verified','cancelled') THEN 1 ELSE 0 END) AS opn, \"",
+        "\"SUM(CASE WHEN state IN ('verified','delivered','cancelled') THEN 1 ELSE 0 END) AS done, \"",
+        "\"SUM(CASE WHEN state NOT IN ('verified','delivered','cancelled') THEN 1 ELSE 0 END) AS opn, \"",
     ),
     "juggle_learnings_rollup.py": (
         "\"AND state='verified'\",",

--- a/src/dbops/threads.py
+++ b/src/dbops/threads.py
@@ -103,8 +103,36 @@ class ThreadsMixin:
                 return row["id"]
         return None
 
+    def _insert_new_conversation(
+        self, conn, new_id: str, topic: str, session_id: str, now_min: str
+    ) -> str | None:
+        """Cap-check + slug-alloc + conversation-node insert on the caller's
+        ``conn`` (caller MUST already hold the write lock). Returns ``new_id``, or
+        ``None`` if at/over the thread cap.
+
+        The SOLE new-conversation writer — shared by BOTH the self-transaction
+        ``create_thread`` path and the caller-transaction (``conn=``) path so a
+        thread is allocated + laid down identically whether created standalone or
+        inside a larger atomic write (one source of truth). P8 c4-write-cut: the
+        cap count and live-set scan both resolve from kind='conversation' nodes,
+        whose unique idx_nodes_live_label enforces the no-shared-live-slug rule."""
+        rows = conn.execute(
+            "SELECT state FROM nodes WHERE kind='conversation'"
+        ).fetchall()
+        active_count = sum(1 for r in rows if r["state"] != "archived")
+        if active_count >= MAX_THREADS:
+            return None
+        user_label = self._next_wheel_slug(conn)
+        # The conversation is a first-class node — the sole store.
+        mirror_conv_insert(
+            conn, new_id, topic=topic, session_id=session_id,
+            user_label=user_label, now=now_min,
+        )
+        return new_id
+
     def create_thread(
-        self, topic: str, session_id: str, project_id: str | None = None
+        self, topic: str, session_id: str, project_id: str | None = None,
+        *, conn=None
     ) -> str:
         """Create a new thread. Returns the UUID of the new thread.
 
@@ -114,19 +142,31 @@ class ThreadsMixin:
         Dedup guard: if an OPEN (same-project, when `project_id` is given)
         thread already exists whose title is a lexical duplicate of `topic`,
         no new row is inserted and that existing thread's id is returned.
+
+        When ``conn`` is passed the conversation node is written on the CALLER'S
+        connection/transaction (no BEGIN/COMMIT of our own), so thread creation can
+        be one step of a larger atomic write — e.g. ``create_loop_atomic`` binds a
+        loop to its own thread inside the same all-or-nothing transaction that lays
+        down the project + graph (the caller already holds the write lock, and its
+        rollback discards the thread too). Over-cap still fails loud via
+        ``_raise_thread_cap`` — which rolls the caller's transaction back.
         """
         existing = self._find_duplicate_open_thread(topic, project_id)
         if existing is not None:
             return existing
         new_id = str(uuid.uuid4())
         now_min = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        if conn is not None:
+            result = self._insert_new_conversation(
+                conn, new_id, topic, session_id, now_min
+            )
+            if result is None:
+                self._raise_thread_cap()  # rolls the caller's transaction back
+            return result
         # ATOMIC allocation (2026-06-21): take the write lock with BEGIN IMMEDIATE
         # BEFORE reading label_seq so the read-modify-write of the counter and the
         # live-set scan are serialized across processes — no two creates can land
         # on the same slug. The retry loop is a backstop for lock contention.
-        # P8 c4-write-cut: the conversation node is the SOLE store; the cap count
-        # and the live-set scan both resolve from kind='conversation' nodes, whose
-        # unique idx_nodes_live_label enforces the no-shared-live-slug invariant.
         with self._connect() as conn:
             conn.isolation_level = None  # manual transaction control
             last_exc: Exception | None = None
@@ -137,23 +177,14 @@ class ThreadsMixin:
                     last_exc = exc  # busy; retry
                     continue
                 try:
-                    rows = conn.execute(
-                        "SELECT state FROM nodes WHERE kind='conversation'"
-                    ).fetchall()
-                    active_count = sum(
-                        1 for r in rows if r["state"] != "archived"
+                    result = self._insert_new_conversation(
+                        conn, new_id, topic, session_id, now_min
                     )
-                    if active_count >= MAX_THREADS:
+                    if result is None:
                         conn.execute("ROLLBACK")
                         break  # over cap — raise structured guidance below
-                    user_label = self._next_wheel_slug(conn)
-                    # The conversation is a first-class node — the sole store.
-                    mirror_conv_insert(
-                        conn, new_id, topic=topic, session_id=session_id,
-                        user_label=user_label, now=now_min,
-                    )
                     conn.execute("COMMIT")
-                    return new_id
+                    return result
                 except sqlite3.IntegrityError as exc:
                     conn.execute("ROLLBACK")
                     last_exc = exc

--- a/src/juggle_cli.py
+++ b/src/juggle_cli.py
@@ -117,6 +117,7 @@ from juggle_cmd_graph import register_graph_parsers
 from juggle_cmd_runs import register_runs_parsers
 from juggle_cmd_spool import register_spool_parsers
 from juggle_cli_parsers_project import register_project_parsers
+from juggle_cli_parsers_loop import register_loop_parsers
 from juggle_cli_aliases import cmd_aliases
 from juggle_cli_aliases import rewrite_argv as _rewrite_legacy_argv
 
@@ -216,6 +217,7 @@ def build_cli_parser(vault_path_default: str | None = None):
     register_runs_parsers(subparsers)
     register_spool_parsers(subparsers)
     register_project_parsers(subparsers)
+    register_loop_parsers(subparsers)
     juggle_cmd_autopilot.register(subparsers)
 
     # vault path / vault name — entry-module verbs folded into the `vault` group

--- a/src/juggle_cli_parsers_loop.py
+++ b/src/juggle_cli_parsers_loop.py
@@ -1,0 +1,25 @@
+"""juggle_cli_parsers_loop — argparse wiring for the `loop <verb>` group
+(loop-entity V1, Phase 4).
+
+V1 registers only `loop create` (the transactional single-topic create the
+schedule:create router calls). `loop list`/`loop delete` are V2.
+Must not own: handler logic (lives in juggle_cmd_loop_create).
+"""
+from __future__ import annotations
+
+from juggle_cmd_loop_create import cmd_loop_create
+
+
+def register_loop_parsers(subparsers) -> None:
+    """Register the `loop <verb>` subcommand group on ``subparsers``."""
+    p_loop = subparsers.add_parser("loop", help="Manage recurring loops")
+    _ls = p_loop.add_subparsers(dest="loop_command", required=True)
+
+    _p = _ls.add_parser("create", help="Create a single-topic loop (transactional)")
+    _p.add_argument("--template", required=True,
+                    help="Path to the validated single-topic template JSON")
+    _p.add_argument("--cadence", required=True,
+                    help="Cadence, e.g. 'every 15m' / 'daily at 09:00'")
+    _p.add_argument("--name", help="Loop project name (default 'loop <L#>')")
+    _p.add_argument("--objective", default="", help="Loop project objective")
+    _p.set_defaults(func=cmd_loop_create)

--- a/src/juggle_cmd_agents_graph_topics.py
+++ b/src/juggle_cmd_agents_graph_topics.py
@@ -18,6 +18,7 @@ import sys
 
 from dbops import event_kinds as _ek
 from dbops.terminal_states import TASK_TERMINAL_STATES as _TASK_TERMINAL
+from dbops.terminal_states import is_success_terminal
 
 
 def check_topic_completion_gate(db, thread_uuid) -> str | None:
@@ -138,12 +139,18 @@ def mark_graph_topic(db, thread_uuid, integrate_ok, handoff, session_id,
         return mark_graph_task(db, thread_uuid, integrate_ok, handoff,
                                session_id, verify_failed=verify_failed)
     tasks = db_topics.list_topic_tasks(db, topic["id"])
-    all_verified = bool(tasks) and all(n["state"] == "verified" for n in tasks)
+    # loop-entity V1 Phase 4 (boundary #2): a deliver loop's member tasks reach
+    # 'delivered' (a success terminal), NOT 'verified'. Gate on the success-terminal
+    # SET (is_success_terminal), not a verified-only literal, so a single-topic
+    # delivery='deliver' loop passes verify_ok=True and mark_topic_completion's
+    # deliver-branch walks it to 'delivered' instead of verify_fail→failed-verify.
+    # A merge topic is unchanged: its tasks are 'verified' (still success-terminal).
+    all_success = bool(tasks) and all(is_success_terminal(n["state"]) for n in tasks)
     try:
         state = db_topics.mark_topic_completion(
             db, topic["id"],
             integrate_ok=integrate_ok or verify_failed,
-            verify_ok=(not verify_failed) and all_verified,
+            verify_ok=(not verify_failed) and all_success,
             handoff=handoff,
         )
     except db_topics.UnmergedVerifyRefused as e:
@@ -178,15 +185,20 @@ def mark_graph_topic(db, thread_uuid, integrate_ok, handoff, session_id,
         _t = db_topics.get_topic(db, topic["id"]) or {}
         db.close_run(
             thread_uuid, output=handoff, diffstat=_t.get("diffstat"),
-            status="completed" if state == "verified" else "failed",
+            status="completed" if is_success_terminal(state) else "failed",
         )
     except Exception:
         pass
 
-    if state == "verified":
+    # loop-entity V1 Phase 4 (boundary #2): 'delivered' is a SUCCESS terminal too,
+    # so both success terminals emit the success event — never the failure branch
+    # (which would file a bogus 'topic failed (delivered)' HIGH item + propagate a
+    # non-existent failure to dependents).
+    if is_success_terminal(state):
+        verb = "verified (merged)" if state == "verified" else "delivered"
         db.emit_event(
             thread_id=thread_uuid,
-            message=f"⬢ topic {topic['id']} verified (merged)",
+            message=f"⬢ topic {topic['id']} {verb}",
             session_id=session_id,
             kind=_ek.TOPIC_STATUS,
         )

--- a/src/juggle_cmd_loop_create.py
+++ b/src/juggle_cmd_loop_create.py
@@ -58,6 +58,13 @@ def compute_next_run(cadence: str, now: datetime | None = None) -> str:
     m = _DAILY_RE.search(cadence or "")
     if m:
         hh, mm = int(m.group(1)), int(m.group(2))
+        if hh > 23 or mm > 59:
+            # The regex accepts \d{1,2}:\d{2} (e.g. 30:70); reject out-of-range as a
+            # LoopTemplateError so cmd_loop_create fails loud instead of a bare
+            # datetime.replace ValueError tracebacking past its except handler.
+            raise LoopTemplateError(
+                f"invalid time in cadence {cadence!r}: {hh:02d}:{mm:02d}"
+            )
         cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
         if cand <= now:
             cand = cand + timedelta(days=1)
@@ -119,6 +126,11 @@ def create_loop_atomic(db, *, template, cadence, name=None, objective="",
                 prompt=task["prompt"], verify_cmd=task["verify_cmd"], conn=conn,
             )
             db_graph.set_task_topic(db, tid, topic_id, conn=conn)
+            # Only role + delivery are persisted in V1 — there is no nodes.model
+            # column yet. The validator still partitions on `model` (differing
+            # models must live in separate topics), but the model-claim predicate +
+            # per-node model persistence are deferred to V2 (plan §6 / critique
+            # Axis-3): a pinned `model` is validated-for-partition, not stored.
             conn.execute(
                 "UPDATE nodes SET role=?, delivery=? WHERE id=? AND kind='task'",
                 (task["role"], task["delivery"], tid),

--- a/src/juggle_cmd_loop_create.py
+++ b/src/juggle_cmd_loop_create.py
@@ -1,0 +1,176 @@
+"""juggle_cmd_loop_create — transactional single-topic loop creation (loop-entity
+V1, Phase 4).
+
+``create_loop_atomic`` is the ATOMIC create (critique §Axis-5): allocating the
+L-id, creating the ``kind='loop'`` project, loading the validated single-topic
+template graph, and inserting the loop row with ``next_run`` all happen inside ONE
+DB transaction on ONE connection. Any step raising rolls the WHOLE thing back
+(``conn.rollback()``), so a half-created loop can never leave a ``kind='loop'``
+project claiming a P-slot, nor an orphan loop/graph row.
+
+Why a single-transaction rollback (not project-close-as-abort): ``close_project``
+only flips ``status='closed'`` — it leaves the projects ROW behind. The atomicity
+contract here is ZERO orphan rows on failure (no project, no loop, no nodes), which
+only a real transactional rollback delivers. The low-level node writers
+(``db_topics.create_topic`` / ``db_graph.create_task`` / ``set_task_topic`` /
+``replace_edges``) all honour a caller-passed ``conn`` and do NOT commit (``_cx``),
+so threading one connection through them makes the create truly all-or-nothing.
+
+Node ids are run-seq namespaced ``<L#>-r0-<base-id>`` (Phase 1 run_seq) so a later
+re-fire (Phase 5) never collides with the guarded-upsert refusal.
+
+The OS-schedule path is unchanged — it reuses ``juggle_scheduler`` and does NOT
+route through here. The unified ``schedule:create`` router (``commands/schedule/
+create.md``) chooses OS-schedule XOR loop, and only the loop branch calls this.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+
+from dbops import db_graph, db_topics
+from dbops.schema import _now
+from juggle_loop_template_validator import LoopTemplateError, validate_loop_template
+
+_CADENCE_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+_CADENCE_RE = re.compile(
+    r"(?:every\s+)?(\d+)\s*(s|m|h|d|sec|second|seconds|min|minute|minutes|"
+    r"hour|hours|day|days)\b",
+    re.IGNORECASE,
+)
+_DAILY_RE = re.compile(r"daily\s+at\s+(\d{1,2}):(\d{2})", re.IGNORECASE)
+
+
+def compute_next_run(cadence: str, now: datetime | None = None) -> str:
+    """Derive the first ``next_run`` ISO timestamp from a cadence string.
+
+    Supports ``every Nm|Nh|Ns|Nd`` (and the spelled-out units) and ``daily at
+    HH:MM``. Fail-loud on an unparseable cadence — a loop with no schedulable
+    next_run would silently never fire (critique §Axis-6: next_run is the timer).
+
+    Defaults to UTC-aware ``datetime.now(timezone.utc)`` so the emitted ISO string
+    is byte-comparable with ``dbops.schema._now()`` — Phase 5's fire check compares
+    ``next_run`` against ``_now()``, and a naive/local timestamp here would make
+    that comparison wrong (tz offset + missing ``+00:00`` suffix)."""
+    now = now or datetime.now(timezone.utc)
+    m = _DAILY_RE.search(cadence or "")
+    if m:
+        hh, mm = int(m.group(1)), int(m.group(2))
+        cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+        if cand <= now:
+            cand = cand + timedelta(days=1)
+        return cand.isoformat()
+    m = _CADENCE_RE.search(cadence or "")
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2).lower()[0]  # s/m/h/d — first letter disambiguates
+        return (now + timedelta(seconds=n * _CADENCE_UNIT_SECONDS[unit])).isoformat()
+    raise LoopTemplateError(
+        f"unparseable cadence {cadence!r} — expected 'every Nm|Nh|Ns|Nd' or "
+        f"'daily at HH:MM'"
+    )
+
+
+def create_loop_atomic(db, *, template, cadence, name=None, objective="",
+                       now=None, max_consecutive_failures=3):
+    """Validate + atomically create a single-topic loop. Returns a dict with
+    ``loop_id``/``project_id``/``topic_id``/``node_ids``/``next_run``.
+
+    The template is validated (partition rule, V1 single-topic) BEFORE any write.
+    All DB writes run on ONE connection with no intermediate commit; any exception
+    rolls back the whole create (ZERO orphan rows)."""
+    norm = validate_loop_template(template)  # raises LoopTemplateError pre-write
+    topic = norm["topics"][0]
+    next_run = compute_next_run(cadence, now)
+
+    conn = db._connect()
+    try:
+        ts = _now()
+        used_p = {r[0] for r in conn.execute("SELECT id FROM projects").fetchall()}
+        project_id = db._next_project_label(used_p)
+        used_l = {r[0] for r in conn.execute("SELECT id FROM loops").fetchall()}
+        loop_id = db._next_loop_label(used_l)
+        run_seq = 0
+        prefix = f"{loop_id}-r{run_seq}-"
+
+        conn.execute(
+            "INSERT INTO projects (id,name,objective,success_criteria,out_of_scope,"
+            "status,kind,created_at,last_active) VALUES (?,?,?,?,?,'active','loop',?,?)",
+            (project_id, name or f"loop {loop_id}", objective, "[]", "", ts, ts),
+        )
+
+        topic_id = f"{prefix}{topic['id']}"
+        db_topics.create_topic(
+            db, topic_id=topic_id, project_id=project_id,
+            title=topic["title"], objective=topic["objective"], conn=conn,
+        )
+        conn.execute(
+            "UPDATE nodes SET delivery=?, role=? WHERE id=? AND kind='topic'",
+            (topic["delivery"], topic["role"], topic_id),
+        )
+
+        node_ids = [topic_id]
+        for task in topic["tasks"]:
+            tid = f"{prefix}{task['id']}"
+            db_graph.create_task(
+                db, task_id=tid, project_id=project_id, title=task["title"],
+                prompt=task["prompt"], verify_cmd=task["verify_cmd"], conn=conn,
+            )
+            db_graph.set_task_topic(db, tid, topic_id, conn=conn)
+            conn.execute(
+                "UPDATE nodes SET role=?, delivery=? WHERE id=? AND kind='task'",
+                (task["role"], task["delivery"], tid),
+            )
+            node_ids.append(tid)
+        for task in topic["tasks"]:
+            deps = sorted(f"{prefix}{d}" for d in task["deps"])
+            if deps:
+                db_graph.replace_edges(db, f"{prefix}{task['id']}", deps, conn=conn)
+
+        conn.execute(
+            "INSERT INTO loops (id, project_id, thread_id, cadence, status, run_seq, "
+            "next_run, last_run_at, consecutive_failures, max_consecutive_failures, "
+            "created_at, updated_at) VALUES (?,?,NULL,?,'active',?,?,NULL,0,?,?,?)",
+            (loop_id, project_id, cadence, run_seq, next_run,
+             max_consecutive_failures, ts, ts),
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()  # ZERO orphan rows — no project, no loop, no nodes
+        raise
+    finally:
+        conn.close()
+
+    return {
+        "loop_id": loop_id, "project_id": project_id, "topic_id": topic_id,
+        "node_ids": node_ids, "next_run": next_run,
+    }
+
+
+def cmd_loop_create(args):
+    """CLI: ``juggle loop create --template <file.json> --cadence '<cadence>'``.
+
+    The unified schedule:create router builds the validated single-topic template
+    JSON, then calls this. Prints the created loop/project/topic ids."""
+    import juggle_cli_common as _common
+
+    db = _common.get_db()
+    try:
+        template = json.loads(open(args.template, encoding="utf-8").read())
+    except (OSError, ValueError) as e:
+        print(f"Error: could not read template {args.template!r}: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        result = create_loop_atomic(
+            db, template=template, cadence=args.cadence,
+            name=getattr(args, "name", None), objective=getattr(args, "objective", "") or "",
+        )
+    except LoopTemplateError as e:
+        print(f"Error: invalid loop template — {e}", file=sys.stderr)
+        sys.exit(1)
+    print(
+        f"Loop {result['loop_id']} created (project {result['project_id']}, topic "
+        f"{result['topic_id']}, next_run {result['next_run']})."
+    )

--- a/src/juggle_cmd_loop_create.py
+++ b/src/juggle_cmd_loop_create.py
@@ -81,13 +81,19 @@ def compute_next_run(cadence: str, now: datetime | None = None) -> str:
 
 
 def create_loop_atomic(db, *, template, cadence, name=None, objective="",
-                       now=None, max_consecutive_failures=3):
+                       now=None, max_consecutive_failures=3, session_id=None):
     """Validate + atomically create a single-topic loop. Returns a dict with
-    ``loop_id``/``project_id``/``topic_id``/``node_ids``/``next_run``.
+    ``loop_id``/``project_id``/``topic_id``/``node_ids``/``next_run``/``thread_id``.
 
     The template is validated (partition rule, V1 single-topic) BEFORE any write.
     All DB writes run on ONE connection with no intermediate commit; any exception
-    rolls back the whole create (ZERO orphan rows)."""
+    rolls back the whole create (ZERO orphan rows).
+
+    The loop is bound to its OWN thread (``loops.thread_id``) so a failing iteration's
+    HIGH action item and any loop-scoped notifications land on that named thread —
+    surfaced in the cockpit ACTION PANE on the loop — instead of the null-thread
+    ORPHAN bucket. The thread is created via the shared ``create_thread`` primitive
+    on THIS connection, so it commits/rolls back atomically with the loop."""
     norm = validate_loop_template(template)  # raises LoopTemplateError pre-write
     topic = norm["topics"][0]
     next_run = compute_next_run(cadence, now)
@@ -116,11 +122,22 @@ def create_loop_atomic(db, *, template, cadence, name=None, objective="",
             db, conn, project_id=project_id, prefix=prefix, topic=topic,
         )
 
+        # The loop's OWN thread — failure action items + loop-scoped notifications
+        # attach here (not the null-thread ORPHAN bucket). Reuses the shared
+        # create_thread primitive on THIS conn (conn=) so the thread commits/rolls
+        # back atomically with the project + graph + loop row.
+        thread_id = db.create_thread(
+            name or f"loop {loop_id}",
+            session_id or f"loop:{loop_id}",
+            project_id=project_id,
+            conn=conn,
+        )
+
         conn.execute(
             "INSERT INTO loops (id, project_id, thread_id, cadence, status, run_seq, "
             "next_run, last_run_at, consecutive_failures, max_consecutive_failures, "
-            "created_at, updated_at) VALUES (?,?,NULL,?,'active',?,?,NULL,0,?,?,?)",
-            (loop_id, project_id, cadence, run_seq, next_run,
+            "created_at, updated_at) VALUES (?,?,?,?,'active',?,?,NULL,0,?,?,?)",
+            (loop_id, project_id, thread_id, cadence, run_seq, next_run,
              max_consecutive_failures, ts, ts),
         )
         conn.commit()
@@ -132,7 +149,7 @@ def create_loop_atomic(db, *, template, cadence, name=None, objective="",
 
     return {
         "loop_id": loop_id, "project_id": project_id, "topic_id": topic_id,
-        "node_ids": node_ids, "next_run": next_run,
+        "node_ids": node_ids, "next_run": next_run, "thread_id": thread_id,
     }
 
 

--- a/src/juggle_cmd_loop_create.py
+++ b/src/juggle_cmd_loop_create.py
@@ -30,8 +30,8 @@ import re
 import sys
 from datetime import datetime, timedelta, timezone
 
-from dbops import db_graph, db_topics
 from dbops.schema import _now
+from juggle_loop_instantiate import instantiate_topic
 from juggle_loop_template_validator import LoopTemplateError, validate_loop_template
 
 _CADENCE_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
@@ -108,38 +108,13 @@ def create_loop_atomic(db, *, template, cadence, name=None, objective="",
             (project_id, name or f"loop {loop_id}", objective, "[]", "", ts, ts),
         )
 
-        topic_id = f"{prefix}{topic['id']}"
-        db_topics.create_topic(
-            db, topic_id=topic_id, project_id=project_id,
-            title=topic["title"], objective=topic["objective"], conn=conn,
+        # Shared writer with the Phase-5 re-fire (juggle_loop_instantiate) — one
+        # source of truth for how an iteration's nodes/edges are laid down. Only
+        # role + delivery are persisted in V1 (no nodes.model column yet; the
+        # validator still partitions on `model` but it is not stored — V2).
+        topic_id, node_ids = instantiate_topic(
+            db, conn, project_id=project_id, prefix=prefix, topic=topic,
         )
-        conn.execute(
-            "UPDATE nodes SET delivery=?, role=? WHERE id=? AND kind='topic'",
-            (topic["delivery"], topic["role"], topic_id),
-        )
-
-        node_ids = [topic_id]
-        for task in topic["tasks"]:
-            tid = f"{prefix}{task['id']}"
-            db_graph.create_task(
-                db, task_id=tid, project_id=project_id, title=task["title"],
-                prompt=task["prompt"], verify_cmd=task["verify_cmd"], conn=conn,
-            )
-            db_graph.set_task_topic(db, tid, topic_id, conn=conn)
-            # Only role + delivery are persisted in V1 — there is no nodes.model
-            # column yet. The validator still partitions on `model` (differing
-            # models must live in separate topics), but the model-claim predicate +
-            # per-node model persistence are deferred to V2 (plan §6 / critique
-            # Axis-3): a pinned `model` is validated-for-partition, not stored.
-            conn.execute(
-                "UPDATE nodes SET role=?, delivery=? WHERE id=? AND kind='task'",
-                (task["role"], task["delivery"], tid),
-            )
-            node_ids.append(tid)
-        for task in topic["tasks"]:
-            deps = sorted(f"{prefix}{d}" for d in task["deps"])
-            if deps:
-                db_graph.replace_edges(db, f"{prefix}{task['id']}", deps, conn=conn)
 
         conn.execute(
             "INSERT INTO loops (id, project_id, thread_id, cadence, status, run_seq, "

--- a/src/juggle_cockpit_graph_dag.py
+++ b/src/juggle_cockpit_graph_dag.py
@@ -53,7 +53,7 @@ def gather_project_activity(conn) -> list[ProjectActivity]:
     """
     try:
         proj_rows = conn.execute(
-            "SELECT id, last_active FROM projects WHERE status='active'"
+            "SELECT id, last_active FROM projects WHERE status='active' AND kind != 'loop'"
         ).fetchall()
     except Exception:
         return []
@@ -64,7 +64,7 @@ def gather_project_activity(conn) -> list[ProjectActivity]:
         for r in conn.execute(
             "SELECT DISTINCT project_id FROM nodes "
             "WHERE kind IN ('topic','task','research') AND parent_id IS NULL "
-            "AND project_id IS NOT NULL"
+            "AND project_id IS NOT NULL AND project_id NOT IN (SELECT id FROM projects WHERE kind='loop')"
         ).fetchall():
             pid = r[0]
             if pid and pid not in last_active:

--- a/src/juggle_cockpit_graph_dag.py
+++ b/src/juggle_cockpit_graph_dag.py
@@ -80,7 +80,7 @@ def gather_project_activity(conn) -> list[ProjectActivity]:
     try:
         for r in conn.execute(
             "SELECT project_id, "
-            "SUM(CASE WHEN state NOT IN ('verified','cancelled') THEN 1 ELSE 0 END) AS opn, "
+            "SUM(CASE WHEN state NOT IN ('verified','delivered','cancelled') THEN 1 ELSE 0 END) AS opn, "
             "COUNT(*) AS total, MAX(COALESCE(verified_at,'')) AS vmax "
             "FROM nodes "
             "WHERE (kind='topic' OR (kind='task' AND parent_id IS NULL)) "
@@ -182,7 +182,7 @@ def _load_one(conn, pid: str) -> "GraphDag | None":
     try:
         count_rows = conn.execute(
             "SELECT parent_id, "
-            "SUM(CASE WHEN state IN ('verified','cancelled') THEN 1 ELSE 0 END) AS done, "
+            "SUM(CASE WHEN state IN ('verified','delivered','cancelled') THEN 1 ELSE 0 END) AS done, "
             "COUNT(*) AS total "
             f"FROM nodes WHERE parent_id IN ({ph}) GROUP BY parent_id",
             topic_ids,

--- a/src/juggle_cockpit_model.py
+++ b/src/juggle_cockpit_model.py
@@ -203,7 +203,7 @@ def snapshot(db, *, load_graph_dag: bool = False) -> CockpitState:
     # Load projects for grouping (graceful fallback for old DBs without the table)
     try:
         proj_rows = conn.execute(
-            "SELECT id, name FROM projects WHERE status != 'archived' ORDER BY (id='INBOX'), id"
+            "SELECT id, name FROM projects WHERE status != 'archived' AND kind != 'loop' ORDER BY (id='INBOX'), id"
         ).fetchall()
         projects_by_id: dict[str, str] = {r[0]: r[1] for r in proj_rows}
     except Exception:

--- a/src/juggle_db.py
+++ b/src/juggle_db.py
@@ -37,6 +37,8 @@ from dbops.schema import (  # noqa: E402, F401
     CREATE_GRAPH_EDGES,
     CREATE_GRAPH_TASKS,
     CREATE_GRAPH_TOPICS,
+    CREATE_LOOPS,
+    CREATE_LOOPS_INDEXES,
     CREATE_MESSAGES,
     CREATE_NOTIFICATIONS,
     CREATE_NOTIFICATIONS_V2,
@@ -59,6 +61,7 @@ from dbops.agents import AgentsMixin  # noqa: E402, F401
 from dbops.messages import MessagesMixin  # noqa: E402, F401
 from dbops.migrations import run_migrations  # noqa: E402, F401
 from dbops.notifications import NotificationsMixin  # noqa: E402, F401
+from dbops.loops import LoopsMixin  # noqa: E402, F401
 from dbops.projects import ProjectsMixin  # noqa: E402, F401
 from dbops.runs import RunsMixin  # noqa: E402, F401
 from dbops.selfheal import SelfhealMixin  # noqa: E402, F401
@@ -76,6 +79,7 @@ class JuggleDB(
     SessionMixin,
     ThreadsMixin,
     ProjectsMixin,
+    LoopsMixin,
     MessagesMixin,
     NotificationsMixin,
     SelfhealMixin,
@@ -172,6 +176,9 @@ class JuggleDB(
             conn.execute(CREATE_ERROR_EVENTS)
             conn.execute(CREATE_SELFHEAL_AUDIT)
             conn.execute(CREATE_PROJECTS)
+            conn.execute(CREATE_LOOPS)
+            for _loops_idx in CREATE_LOOPS_INDEXES:
+                conn.execute(_loops_idx)
             conn.execute(CREATE_SPOOL_JOURNAL)
             conn.execute(CREATE_GRAPH_TASKS)
             conn.execute(CREATE_GRAPH_EDGES)

--- a/src/juggle_graph_dispatch.py
+++ b/src/juggle_graph_dispatch.py
@@ -316,88 +316,6 @@ def graph_tick(db, mgr=None, *, dispatch_fn=None) -> dict:
     return stats
 
 
-def _dispatch_flat_task_fallback(
-    db, all_projects: list[str], stats: dict, dispatch
-) -> None:
-    """Dispatch ready graph tasks that have NO graph-topic home (parent_id NULL).
-
-    Belt-and-suspenders so a parentless orphan never silently stalls a project
-    (2026-06-30 orphan-task dispatch gap). Covers both a flat project with ZERO
-    graph-topics (every task parentless) and a stray orphan in a project that
-    HAS (completed) topics — the old code skipped the whole project the moment it
-    had ≥1 topic, stranding these tasks forever. A task WITH a topic parent is the
-    topic path's job (the topic agent carries all its members), never re-dispatched
-    here — so ONLY parentless (topic_id NULL) tasks are true orphans."""
-    from juggle_graph_hydration import hydrate_for_task
-
-    for pid in all_projects:
-        try:
-            stats["swept"] += sweep_stale_claims(db, pid)
-            db_graph.recompute_ready(db, pid)
-            tasks = [
-                n
-                for n in db_graph.list_tasks(db, pid)
-                if n["state"] == "ready" and n.get("topic_id") is None
-            ]
-        except Exception:
-            _log.exception(
-                "graph tick (flat fallback): ready-set scan failed for %s", pid
-            )
-            continue
-        for task in tasks:
-            task_id = task["id"]
-            fail_key = (str(db.db_path), task_id)
-            try:
-                if not claim_task(db, task_id):
-                    continue
-                try:
-                    thread_id = db.create_thread(
-                        f"[{task_id}] {task['title']}"[:80],
-                        session_id=_session_id(db),
-                        project_id=pid,
-                    )
-                except ValueError as e:
-                    db_graph.task_transition(db, task_id, "stale_reset")
-                    if "Maximum of" not in str(e):
-                        stats["errors"].append(task_id)
-                    else:
-                        stats["deferred"].append(task_id)
-                        _log.info("graph tick (flat): thread cap — task %s deferred", task_id)
-                    continue
-                db.update_thread(thread_id, project_id=pid)
-                db_graph.set_task_thread(db, task_id, thread_id)
-                try:
-                    dispatch(db, thread_id, hydrate_for_task(db, pid, task), task)
-                except CapacityError:
-                    db.archive_thread(thread_id)
-                    db_graph.set_task_thread(db, task_id, None)
-                    db_graph.task_transition(db, task_id, "stale_reset")
-                    stats["deferred"].append(task_id)
-                    break
-                except Exception as e:
-                    db.archive_thread(thread_id)
-                    db_graph.set_task_thread(db, task_id, None)
-                    stats["errors"].append(task_id)
-                    fails = _dispatch_fails.get(fail_key, 0) + 1
-                    _dispatch_fails[fail_key] = fails
-                    if fails >= MAX_DISPATCH_FAILS:
-                        _dispatch_fails.pop(fail_key, None)
-                        _give_up_dispatch(db, task_id, e)
-                    else:
-                        db_graph.task_transition(db, task_id, "stale_reset")
-                    continue
-                _dispatch_fails.pop(fail_key, None)
-                db_graph.task_transition(db, task_id, "dispatch")
-                db.emit_event(
-                    thread_id=thread_id, session_id=_session_id(db), kind=_ek.AUTOPILOT_DISPATCH,
-                    message=f"⬢ autopilot dispatched task {task_id} — {task['title']}",
-                )
-                stats["dispatched"].append(task_id)
-            except Exception:
-                _log.exception("graph tick (flat fallback): error on task %s", task_id)
-                stats["errors"].append(task_id)
-
-
 def _session_id(db) -> str:
     with db._connect() as conn:
         return db._get_session_key(conn, "session_id") or ""
@@ -407,4 +325,10 @@ def _session_id(db) -> str:
 # re-exported here for graph_tick + callers/tests (bottom import breaks the cycle).
 from juggle_graph_dispatch_topics import (  # noqa: E402, F401
     _give_up_topic_dispatch, claim_topic, reusable_thread, sweep_stale_topic_claims)
+
+# Legacy flat-task fallback lives in juggle_graph_dispatch_flat (LOC gate,
+# loop-entity Phase 2), re-exported here so graph_tick + callers/tests keep
+# calling ``_dispatch_flat_task_fallback`` unchanged (bottom import breaks the
+# cycle — the flat module imports the claim/sweep/give-up helpers defined above).
+from juggle_graph_dispatch_flat import _dispatch_flat_task_fallback  # noqa: E402, F401
 

--- a/src/juggle_graph_dispatch.py
+++ b/src/juggle_graph_dispatch.py
@@ -96,16 +96,36 @@ from juggle_graph_hydration import (  # noqa: E402, F401
 # ── dispatch path ──────────────────────────────────────────────────────────────
 
 
-def _dispatch_via_pool(db, thread_id: str, prompt: str, task: dict) -> None:
-    """Dispatch ``prompt`` for ``thread_id`` via dispatch_node() (P3).
+def _resolve_dispatch_role(db, node: dict | None) -> str:
+    """The role a node/topic dispatches as (loop-entity Phase 2).
 
-    dispatch_node owns the acquire-agent + send-task logic so the tick no
-    longer routes through the user-facing get-agent/send-task CLI commands.
-    Raises CapacityError (pool full → defer) or RuntimeError.
-    """
+    Reads nodes.role by id (Phase-1 column, DEFAULT 'coder' → legacy graphs
+    unchanged), preferring any 'role' the caller already hydrated onto the dict,
+    then falling back to 'coder'. coder/planner get an isolated worktree (the
+    send-path gate keys off the acquired agent's role); researcher runs
+    read-only in place (no worktree)."""
+    node = node or {}
+    role = node.get("role")
+    nid = node.get("id")
+    if not role and nid:
+        try:
+            with db._connect() as conn:
+                row = conn.execute(
+                    "SELECT role FROM nodes WHERE id=?", (nid,)
+                ).fetchone()
+            role = (row["role"] if not isinstance(row, tuple) else row[0]) if row else None
+        except Exception:
+            role = None
+    return role or TASK_ROLE
+
+
+def _dispatch_via_pool(db, thread_id: str, prompt: str, task: dict) -> None:
+    """Dispatch ``prompt`` via dispatch_node(), resolving the role PER NODE
+    (loop-entity Phase 2 — no longer hardcoded coder; researcher gets no
+    worktree). Raises CapacityError (pool full → defer) or RuntimeError."""
     from juggle_dispatch_core import dispatch_node
 
-    dispatch_node(db, thread_id, prompt, task, role=TASK_ROLE)
+    dispatch_node(db, thread_id, prompt, task, role=_resolve_dispatch_role(db, task))
 
 
 def _give_up_dispatch(db, task_id: str, err: Exception) -> None:

--- a/src/juggle_graph_dispatch_flat.py
+++ b/src/juggle_graph_dispatch_flat.py
@@ -1,0 +1,112 @@
+"""juggle_graph_dispatch_flat — legacy flat-task fallback dispatch (R9/R6).
+
+Extracted from juggle_graph_dispatch (2026-07-04, loop-entity Phase 2 LOC gate:
+the dispatcher module was at its 410-line allowlist budget and Phase 2's
+per-node role resolution needed headroom). ZERO behaviour change — the
+``_dispatch_flat_task_fallback`` body is moved verbatim; juggle_graph_dispatch
+re-exports it (bottom import) so ``gd._dispatch_flat_task_fallback`` and the
+tick keep calling it unchanged.
+
+The claim/sweep/give-up helpers this module needs live in juggle_graph_dispatch;
+they are imported LAZILY inside the function (not at module top) so this module
+is import-safe in either order — a top-level ``from juggle_graph_dispatch import``
+would deadlock the cycle when flat is imported before gd.
+
+Owns: dispatching ready graph tasks that have NO graph-topic home (parentless
+orphans) — the belt-and-suspenders so a parentless task never silently stalls
+a project.
+Must not own: the topic tick loop / hydration / claim semantics
+(juggle_graph_dispatch), task state semantics (dbops.db_graph).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dbops import db_graph
+from dbops import event_kinds as _ek
+
+_log = logging.getLogger("juggle-graph-dispatch")
+
+
+def _dispatch_flat_task_fallback(
+    db, all_projects: list[str], stats: dict, dispatch
+) -> None:
+    """Dispatch ready graph tasks that have NO graph-topic home (parent_id NULL).
+
+    Belt-and-suspenders so a parentless orphan never silently stalls a project
+    (2026-06-30 orphan-task dispatch gap). Covers both a flat project with ZERO
+    graph-topics (every task parentless) and a stray orphan in a project that
+    HAS (completed) topics — the old code skipped the whole project the moment it
+    had ≥1 topic, stranding these tasks forever. A task WITH a topic parent is the
+    topic path's job (the topic agent carries all its members), never re-dispatched
+    here — so ONLY parentless (topic_id NULL) tasks are true orphans."""
+    import juggle_graph_dispatch as _gd  # lazy — breaks the flat⇄gd import cycle
+    from juggle_graph_hydration import hydrate_for_task
+
+    for pid in all_projects:
+        try:
+            stats["swept"] += _gd.sweep_stale_claims(db, pid)
+            db_graph.recompute_ready(db, pid)
+            tasks = [
+                n
+                for n in db_graph.list_tasks(db, pid)
+                if n["state"] == "ready" and n.get("topic_id") is None
+            ]
+        except Exception:
+            _log.exception(
+                "graph tick (flat fallback): ready-set scan failed for %s", pid
+            )
+            continue
+        for task in tasks:
+            task_id = task["id"]
+            fail_key = (str(db.db_path), task_id)
+            try:
+                if not _gd.claim_task(db, task_id):
+                    continue
+                try:
+                    thread_id = db.create_thread(
+                        f"[{task_id}] {task['title']}"[:80],
+                        session_id=_gd._session_id(db),
+                        project_id=pid,
+                    )
+                except ValueError as e:
+                    db_graph.task_transition(db, task_id, "stale_reset")
+                    if "Maximum of" not in str(e):
+                        stats["errors"].append(task_id)
+                    else:
+                        stats["deferred"].append(task_id)
+                        _log.info("graph tick (flat): thread cap — task %s deferred", task_id)
+                    continue
+                db.update_thread(thread_id, project_id=pid)
+                db_graph.set_task_thread(db, task_id, thread_id)
+                try:
+                    dispatch(db, thread_id, hydrate_for_task(db, pid, task), task)
+                except _gd.CapacityError:
+                    db.archive_thread(thread_id)
+                    db_graph.set_task_thread(db, task_id, None)
+                    db_graph.task_transition(db, task_id, "stale_reset")
+                    stats["deferred"].append(task_id)
+                    break
+                except Exception as e:
+                    db.archive_thread(thread_id)
+                    db_graph.set_task_thread(db, task_id, None)
+                    stats["errors"].append(task_id)
+                    fails = _gd._dispatch_fails.get(fail_key, 0) + 1
+                    _gd._dispatch_fails[fail_key] = fails
+                    if fails >= _gd.MAX_DISPATCH_FAILS:
+                        _gd._dispatch_fails.pop(fail_key, None)
+                        _gd._give_up_dispatch(db, task_id, e)
+                    else:
+                        db_graph.task_transition(db, task_id, "stale_reset")
+                    continue
+                _gd._dispatch_fails.pop(fail_key, None)
+                db_graph.task_transition(db, task_id, "dispatch")
+                db.emit_event(
+                    thread_id=thread_id, session_id=_gd._session_id(db), kind=_ek.AUTOPILOT_DISPATCH,
+                    message=f"⬢ autopilot dispatched task {task_id} — {task['title']}",
+                )
+                stats["dispatched"].append(task_id)
+            except Exception:
+                _log.exception("graph tick (flat fallback): error on task %s", task_id)
+                stats["errors"].append(task_id)

--- a/src/juggle_graph_status.py
+++ b/src/juggle_graph_status.py
@@ -12,6 +12,8 @@ not the legacy graph_tasks table — the write-cut no longer populates it.
 
 from __future__ import annotations
 
+from dbops.terminal_states import TERMINAL_SUCCESS_STATES as _DONE_STATES
+
 FAILED_STATES = ("failed-exec", "failed-integration", "failed-verify")
 # dispatching/integrating are transient execution states — fold into "running"
 # for display so operators see "in flight", not scheduler internals.
@@ -29,7 +31,8 @@ def counts_from_states(states: list[str]) -> dict:
     """Aggregate raw task-node state values into display counts. Pure."""
     return {
         "total": len(states),
-        "verified": sum(1 for s in states if s == "verified"),
+        # "done" numerator: BOTH success-terminals (verified + delivered, Phase 3)
+        "verified": sum(1 for s in states if s in _DONE_STATES),
         "failed": sum(1 for s in states if s in FAILED_STATES),
         "blocked": sum(1 for s in states if s == "blocked-failed"),
         "ready": sum(1 for s in states if s == "ready"),

--- a/src/juggle_loop_fire.py
+++ b/src/juggle_loop_fire.py
@@ -38,6 +38,7 @@ import os
 from datetime import datetime
 
 from dbops import event_kinds as _ek
+from dbops.schema import _now as _now_ts
 from dbops.terminal_states import FAILURE_TERMINAL_STATES, TERMINAL_STATES
 from juggle_loop_instantiate import instantiate_topic
 
@@ -170,7 +171,11 @@ def _reconstruct_topic(db, loop: dict) -> dict:
                 "SELECT depends_on_id FROM node_edges WHERE node_id=? AND kind='dep'",
                 (tr["id"],),
             ).fetchall()
-            deps[tr["id"]] = [d[0][base:] for d in drows]
+            # Only strip the r0 prefix off deps that actually carry it (code-review
+            # #5): a dep pointing outside the loop's r0 namespace would otherwise be
+            # mis-stripped into a bogus re-prefixed edge. V1 single-topic templates
+            # are self-contained so this can't happen today — defensive hardening.
+            deps[tr["id"]] = [d[0][base:] for d in drows if d[0].startswith(src_prefix)]
     tasks = [{
         "id": tr["id"][base:], "title": tr["title"], "prompt": tr["objective"],
         "role": tr["role"], "delivery": tr["delivery"], "verify_cmd": tr["verify_cmd"],
@@ -183,14 +188,28 @@ def _reconstruct_topic(db, loop: dict) -> dict:
     }
 
 
-def _instantiate_next_iteration(db, loop: dict, run_seq: int) -> None:
-    """Materialize iteration ``run_seq`` from the reconstructed template, all-or-nothing."""
-    topic = _reconstruct_topic(db, loop)
-    prefix = f"{loop['id']}-r{run_seq}-"
+def _fire_next_iteration_atomic(db, loop: dict) -> int:
+    """Bump run_seq AND instantiate the iteration in ONE transaction; return the new
+    run_seq.
+
+    The seq bump and the node instantiation commit together (code-review #2, RED-pin
+    test_failed_instantiate_rolls_back_seq_bump): if instantiate raises, the seq bump
+    rolls back too, so there is NEVER a bumped run_seq with zero task nodes — an empty
+    iteration would otherwise read as a phantom 'success' next window, silently
+    resetting the circuit-breaker and masking the failure."""
+    topic = _reconstruct_topic(db, loop)  # reads committed r0 nodes (own conn)
     conn = db._connect()
     try:
+        row = conn.execute(
+            "UPDATE loops SET run_seq = run_seq + 1, updated_at = ? WHERE id = ? "
+            "RETURNING run_seq",
+            (_now_ts(), loop["id"]),
+        ).fetchone()
+        new_seq = row[0]
+        prefix = f"{loop['id']}-r{new_seq}-"
         instantiate_topic(db, conn, project_id=loop["project_id"], prefix=prefix, topic=topic)
         conn.commit()
+        return new_seq
     except Exception:
         conn.rollback()
         raise
@@ -235,8 +254,7 @@ def _fire_one(db, loop: dict, session_id: str, now: str) -> str:
         db.reset_consecutive_failures(loop_id)
 
     _SKIP_COUNTS[loop_id] = 0  # a real fire clears the overlap-skip streak
-    new_seq = db.advance_run_seq(loop_id)
-    _instantiate_next_iteration(db, loop, new_seq)
+    new_seq = _fire_next_iteration_atomic(db, loop)  # seq bump + instantiate atomic
     db.stamp_last_run(loop_id)
     _log.info("Loop %s fired iteration r%d", loop_id, new_seq)
     return "fired"
@@ -246,8 +264,7 @@ def fire_due_loops(db, session_id: str, now: str | None = None) -> list[tuple[st
     """Fire every ``active`` loop whose ``next_run`` is due. Returns ``[(loop_id,
     action)]``. A tick with no due loop is a pure no-op (preserves non-loop tick
     behaviour). Per-loop failures are isolated so one bad loop never downs the tick."""
-    from dbops.schema import _now
-    now = now or _now()
+    now = now or _now_ts()
     results: list[tuple[str, str]] = []
     for loop in db.list_active_loops():
         nr = loop.get("next_run")
@@ -255,7 +272,21 @@ def fire_due_loops(db, session_id: str, now: str | None = None) -> list[tuple[st
             continue  # not due (or never scheduled)
         try:
             results.append((loop["id"], _fire_one(db, loop, session_id, now)))
-        except Exception:
-            _log.exception("Loop %s fire failed — continuing", loop.get("id"))
+        except Exception as exc:
+            # A fire-step machinery error (reconstruct/instantiate/DB failure) is a
+            # machinery-error class event — per the triage ladder it pushes the
+            # orchestrator IMMEDIATELY and must NEVER be swallowed to a log line
+            # (code-review #1, user never-swallow directive). Route it through the
+            # same choke point; guard so surfacing itself can't down the tick.
+            _log.exception("Loop %s fire failed — surfacing", loop.get("id"))
+            try:
+                surface_iteration_failure(
+                    db, loop, session_id,
+                    err=f"loop fire machinery error: {exc}",
+                    seq=loop.get("run_seq", -1),
+                )
+            except Exception:
+                _log.exception("Loop %s failure-surface ALSO failed — continuing",
+                               loop.get("id"))
             results.append((loop.get("id"), "error"))
     return results

--- a/src/juggle_loop_fire.py
+++ b/src/juggle_loop_fire.py
@@ -1,0 +1,261 @@
+"""juggle_loop_fire — CAS-safe watchdog loop firing + failure circuit-breaker +
+never-swallow iteration-failure surfacing (loop-entity V1, Phase 5, 2026-07-04).
+
+The watchdog tick calls ``fire_due_loops`` every poll. For each ``active`` loop
+whose ``next_run`` is due it:
+
+  1. **Advances next_run via CAS BEFORE instantiating** (mirrors dbops.state_write.
+     cas_state): the winning tick owns the window; a crash/retry between fire and
+     advance can never double-fire (critique §Axis-7b). The singleton flock already
+     serializes tick-vs-tick; CAS covers crash-between-fire-and-advance.
+  2. **Evaluates the PRIOR iteration's outcome** (a loop iteration is a template
+     graph that runs over many ticks; its success/failure is only known once its
+     nodes reach a terminal state):
+       * still in-flight  → OVERLAP: skip + log; K consecutive skips ESCALATE
+                            (never skip-forever — §Axis-2 Objection B).
+       * failed           → surface (all three, below) + bump the breaker counter;
+                            at ``max_consecutive_failures`` → pause + escalate.
+       * success/first    → reset the breaker counter, then fire the next iteration.
+  3. **Instantiates the next iteration** (run-seq namespaced) as fresh nodes.
+
+**Never-swallow failure surfacing (user directive 2026-07-04 — LOAD-BEARING).**
+``surface_iteration_failure`` is the SINGLE choke point every iteration failure
+flows through; it NEVER swallows the error state and does all three, reusing
+existing primitives:
+  (a) ``db.emit_event(kind=LOOP_ITERATION_FAILED)`` — a notifications_v2 row
+      carrying the ACTUAL non-empty error text, derived-routed to ``orchestrator``
+      (this row is BOTH the error-carrying notification AND the orchestrator push).
+  (b) ``db.add_action_item_once(..., priority='high')`` — a HIGH action item on
+      the loop's thread, visible in the cockpit action pane (deduped so a loop
+      failing every tick does not flood the pane).
+  (c) the orchestrator push — the (a) event's ``handled_by='orchestrator'`` routing
+      (same mechanism as MACHINERY_ERROR / REPAIR_EXHAUSTED / LEARNINGS_ROLLUP).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+from dbops import event_kinds as _ek
+from dbops.terminal_states import FAILURE_TERMINAL_STATES, TERMINAL_STATES
+from juggle_loop_instantiate import instantiate_topic
+
+_log = logging.getLogger("juggle.loop_fire")
+
+# In-process consecutive-overlap-skip tracker (keyed by loop id). The watchdog is a
+# long-running process so this persists across ticks (same pattern as the daemon's
+# _stall_tracker / _enter_sent). K skips → escalate + reset. A wedged iteration must
+# surface, never silently kill the loop by skipping forever (§Axis-2 Objection B).
+_SKIP_COUNTS: dict[str, int] = {}
+
+
+def reset_skip_tracker() -> None:
+    """Clear the in-process overlap-skip tracker (test isolation / daemon restart)."""
+    _SKIP_COUNTS.clear()
+
+
+def max_skips() -> int:
+    """K — consecutive overlap-skips before escalating a wedged iteration."""
+    try:
+        return max(1, int(os.environ.get("JUGGLE_LOOP_MAX_SKIPS", "3")))
+    except ValueError:
+        return 3
+
+
+def _parse(ts: str) -> datetime:
+    return datetime.fromisoformat(ts)
+
+
+def iteration_outcome(db, project_id: str, loop_id: str, seq: int) -> tuple[str, str]:
+    """Classify iteration ``seq`` of ``loop_id`` from its task nodes' states.
+
+    Returns ``(status, detail)`` where status is one of ``in_flight`` / ``failed`` /
+    ``success`` and ``detail`` names the failed node(s)/state(s) (non-empty only for
+    a failure — that string is the surfaced error text). An iteration with no task
+    nodes reads ``success`` (nothing to wait on)."""
+    with db._connect() as conn:
+        rows = conn.execute(
+            "SELECT id, state FROM nodes WHERE kind='task' AND project_id=? AND id LIKE ?",
+            (project_id, f"{loop_id}-r{seq}-%"),
+        ).fetchall()
+    tasks = [(r[0], r[1]) for r in rows]
+    if not tasks:
+        return ("success", "")
+    if any(state not in TERMINAL_STATES for _, state in tasks):
+        return ("in_flight", "")
+    failed = [(nid, state) for nid, state in tasks if state in FAILURE_TERMINAL_STATES]
+    if failed:
+        return ("failed", ", ".join(f"{nid}={state}" for nid, state in failed))
+    return ("success", "")
+
+
+def surface_iteration_failure(db, loop: dict, session_id: str, *, err: str,
+                              seq: int) -> None:
+    """The single never-swallow choke point for ANY loop iteration failure.
+
+    Does all three (emit orchestrator event with the real error, file a HIGH action
+    item, push the orchestrator) reusing existing primitives — and swallows NOTHING.
+    """
+    loop_id = loop["id"]
+    thread_id = loop.get("thread_id")
+    detail = err.strip() or f"iteration r{seq} failed (no detail)"  # NEVER empty
+    # (a)+(c): orchestrator-routed notification carrying the actual error state. The
+    # LOOP_ITERATION_FAILED kind derives handled_by='orchestrator', so this one row
+    # is BOTH the error-carrying notifications_v2 event and the orchestrator push.
+    db.emit_event(
+        thread_id=thread_id,
+        message=f"[Loop {loop_id}] iteration r{seq} failed: {detail}",
+        session_id=session_id,
+        kind=_ek.LOOP_ITERATION_FAILED,
+    )
+    # (b): a HIGH action item on the loop's thread. Message is loop-scoped + STABLE
+    # (no per-iteration seq) so add_action_item_once dedups a repeatedly-failing loop
+    # to ONE open item instead of stacking one per tick — while (a) still re-pushes
+    # the orchestrator every failure.
+    db.add_action_item_once(
+        thread_id,
+        f"Loop {loop_id} iteration failing — needs attention",
+        "loop_failure",
+        priority="high",
+    )
+    _log.warning("Loop %s iteration r%d failed: %s", loop_id, seq, detail)
+
+
+def _handle_overlap(db, loop: dict, session_id: str, seq: int) -> str:
+    """Prior iteration still in-flight → skip this window; escalate after K skips."""
+    loop_id = loop["id"]
+    n = _SKIP_COUNTS.get(loop_id, 0) + 1
+    _SKIP_COUNTS[loop_id] = n
+    _log.info("Loop %s overlap-skip #%d (iteration r%d still in-flight)", loop_id, n, seq)
+    if n >= max_skips():
+        # A wedged iteration that never terminates is a machinery/judgment event —
+        # surface it through the same never-swallow choke point (orchestrator push).
+        surface_iteration_failure(
+            db, loop, session_id,
+            err=f"prior iteration r{seq} still in-flight after {n} skips (wedged)",
+            seq=seq,
+        )
+        _SKIP_COUNTS[loop_id] = 0
+        return "escalated"
+    return "skipped"
+
+
+def _reconstruct_topic(db, loop: dict) -> dict:
+    """Rebuild the normalized template topic from the loop's canonical r0 nodes.
+
+    The loops row does not store the template JSON (no column in V1); the original
+    iteration-0 nodes ARE the template. Strip the ``<L#>-r0-`` prefix off each node
+    id to recover the base template ids, then hand a normalized topic dict to the
+    shared ``instantiate_topic`` writer under the new run-seq prefix."""
+    loop_id, project_id = loop["id"], loop["project_id"]
+    src_prefix = f"{loop_id}-r0-"
+    base = len(src_prefix)
+    with db._connect() as conn:
+        topic_row = conn.execute(
+            "SELECT id, title, objective, role, delivery FROM nodes "
+            "WHERE kind='topic' AND project_id=? AND id LIKE ? LIMIT 1",
+            (project_id, src_prefix + "%"),
+        ).fetchone()
+        if topic_row is None:
+            raise ValueError(f"loop {loop_id!r} has no r0 template topic to re-fire")
+        task_rows = conn.execute(
+            "SELECT id, title, objective, verify_cmd, role, delivery FROM nodes "
+            "WHERE kind='task' AND project_id=? AND id LIKE ? ORDER BY created_at, id",
+            (project_id, src_prefix + "%"),
+        ).fetchall()
+        deps = {}
+        for tr in task_rows:
+            drows = conn.execute(
+                "SELECT depends_on_id FROM node_edges WHERE node_id=? AND kind='dep'",
+                (tr["id"],),
+            ).fetchall()
+            deps[tr["id"]] = [d[0][base:] for d in drows]
+    tasks = [{
+        "id": tr["id"][base:], "title": tr["title"], "prompt": tr["objective"],
+        "role": tr["role"], "delivery": tr["delivery"], "verify_cmd": tr["verify_cmd"],
+        "deps": deps[tr["id"]],
+    } for tr in task_rows]
+    return {
+        "id": topic_row["id"][base:], "title": topic_row["title"],
+        "objective": topic_row["objective"], "role": topic_row["role"],
+        "delivery": topic_row["delivery"], "tasks": tasks,
+    }
+
+
+def _instantiate_next_iteration(db, loop: dict, run_seq: int) -> None:
+    """Materialize iteration ``run_seq`` from the reconstructed template, all-or-nothing."""
+    topic = _reconstruct_topic(db, loop)
+    prefix = f"{loop['id']}-r{run_seq}-"
+    conn = db._connect()
+    try:
+        instantiate_topic(db, conn, project_id=loop["project_id"], prefix=prefix, topic=topic)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _fire_one(db, loop: dict, session_id: str, now: str) -> str:
+    """Fire (or skip/escalate/pause) a single due loop. Returns the action taken."""
+    loop_id = loop["id"]
+    cadence = loop["cadence"]
+    expected = loop["next_run"]
+
+    # Advance next_run via CAS BEFORE any instantiation (crash/double-fire guard).
+    from juggle_cmd_loop_create import compute_next_run
+    new_next = compute_next_run(cadence, now=_parse(expected))
+    if db.advance_next_run_cas(loop_id, expected=expected, new=new_next) != 1:
+        return "raced"  # another tick/process already claimed this window
+
+    loop = db.get_loop(loop_id)  # reload fresh (run_seq, counters)
+    prior_seq = loop["run_seq"]
+    status, detail = iteration_outcome(db, loop["project_id"], loop_id, prior_seq)
+
+    if status == "in_flight":
+        return _handle_overlap(db, loop, session_id, prior_seq)
+
+    if status == "failed":
+        surface_iteration_failure(db, loop, session_id, err=detail, seq=prior_seq)
+        n = db.bump_consecutive_failures(loop_id)
+        if n >= loop["max_consecutive_failures"]:
+            db.pause_loop(loop_id)
+            db.emit_event(
+                thread_id=loop.get("thread_id"),
+                message=(f"[Loop {loop_id}] circuit-breaker tripped — paused after "
+                         f"{n} consecutive failed iterations"),
+                session_id=session_id,
+                kind=_ek.LOOP_PAUSED,
+            )
+            _log.warning("Loop %s paused (breaker: %d consecutive failures)", loop_id, n)
+            return "paused"
+    else:  # success (or first fire with no prior work)
+        db.reset_consecutive_failures(loop_id)
+
+    _SKIP_COUNTS[loop_id] = 0  # a real fire clears the overlap-skip streak
+    new_seq = db.advance_run_seq(loop_id)
+    _instantiate_next_iteration(db, loop, new_seq)
+    db.stamp_last_run(loop_id)
+    _log.info("Loop %s fired iteration r%d", loop_id, new_seq)
+    return "fired"
+
+
+def fire_due_loops(db, session_id: str, now: str | None = None) -> list[tuple[str, str]]:
+    """Fire every ``active`` loop whose ``next_run`` is due. Returns ``[(loop_id,
+    action)]``. A tick with no due loop is a pure no-op (preserves non-loop tick
+    behaviour). Per-loop failures are isolated so one bad loop never downs the tick."""
+    from dbops.schema import _now
+    now = now or _now()
+    results: list[tuple[str, str]] = []
+    for loop in db.list_active_loops():
+        nr = loop.get("next_run")
+        if not nr or nr > now:
+            continue  # not due (or never scheduled)
+        try:
+            results.append((loop["id"], _fire_one(db, loop, session_id, now)))
+        except Exception:
+            _log.exception("Loop %s fire failed — continuing", loop.get("id"))
+            results.append((loop.get("id"), "error"))
+    return results

--- a/src/juggle_loop_instantiate.py
+++ b/src/juggle_loop_instantiate.py
@@ -1,0 +1,56 @@
+"""juggle_loop_instantiate — instantiate a normalized loop-template topic into a
+graph under a run-seq prefix (loop-entity V1).
+
+Extracted (mechanical, behaviour-neutral) from ``juggle_cmd_loop_create`` so BOTH
+the Phase-4 transactional create AND the Phase-5 watchdog re-fire share ONE writer
+for the "materialize a template topic + its member tasks + dep edges under a
+``<L#>-r<seq>-`` prefix" step. One source of truth for how an iteration's nodes are
+laid down keeps create and re-fire from drifting.
+
+Pure over the caller's ``conn`` — never commits (the caller owns the transaction).
+Node ids are ``<prefix><base-id>`` so each iteration's ids are run-seq namespaced
+and never collide with the guarded-upsert refusal (juggle_graph_load).
+"""
+from __future__ import annotations
+
+from dbops import db_graph, db_topics
+
+
+def instantiate_topic(db, conn, *, project_id: str, prefix: str, topic: dict):
+    """Materialize normalized ``topic`` under ``prefix`` into ``project_id`` on the
+    caller-supplied ``conn`` (no commit). Returns ``(topic_id, node_ids)``.
+
+    ``topic`` shape (validator/reconstruct output): ``{id, title, objective, role,
+    delivery, tasks: [{id, title, prompt, role, delivery, verify_cmd, deps}]}``.
+    Only ``role``/``delivery`` are persisted per node (no nodes.model column in V1).
+    """
+    topic_id = f"{prefix}{topic['id']}"
+    db_topics.create_topic(
+        db, topic_id=topic_id, project_id=project_id,
+        title=topic["title"], objective=topic.get("objective", ""), conn=conn,
+    )
+    conn.execute(
+        "UPDATE nodes SET delivery=?, role=? WHERE id=? AND kind='topic'",
+        (topic["delivery"], topic["role"], topic_id),
+    )
+
+    node_ids = [topic_id]
+    for task in topic["tasks"]:
+        tid = f"{prefix}{task['id']}"
+        db_graph.create_task(
+            db, task_id=tid, project_id=project_id, title=task["title"],
+            prompt=task["prompt"], verify_cmd=task.get("verify_cmd"), conn=conn,
+        )
+        db_graph.set_task_topic(db, tid, topic_id, conn=conn)
+        conn.execute(
+            "UPDATE nodes SET role=?, delivery=? WHERE id=? AND kind='task'",
+            (task["role"], task["delivery"], tid),
+        )
+        node_ids.append(tid)
+
+    for task in topic["tasks"]:
+        deps = sorted(f"{prefix}{d}" for d in task.get("deps", []))
+        if deps:
+            db_graph.replace_edges(db, f"{prefix}{task['id']}", deps, conn=conn)
+
+    return topic_id, node_ids

--- a/src/juggle_loop_template_validator.py
+++ b/src/juggle_loop_template_validator.py
@@ -1,0 +1,140 @@
+"""juggle_loop_template_validator — deterministic loop-template partition validator
+(loop-entity V1, Phase 4).
+
+The partition rule ("same (role, model) → ONE topic; differing → SEPARATE topics",
+critique §Axis-4) is enforced HERE, in code, at create time — NEVER trusted as raw
+LLM output. For V1 single-topic loops this validator:
+
+  * asserts the template is exactly ONE topic (V1 scope guard — multi-topic is V2),
+  * asserts the topic has ≥1 member task,
+  * asserts every member task agrees on its ``(role, model, delivery)`` signature
+    (intra-topic homogeneity — a mixed-role/-model/-delivery topic is rejected so
+    a later per-node dispatch never straddles two contracts inside one topic),
+  * NORMALISES the topic: lifts the shared ``role``/``delivery`` onto the topic and
+    fills each task's ``role``/``delivery`` from the shared signature.
+
+Pure data in / data out — no DB, no I/O. The transactional create
+(``juggle_cmd_loop_create``) calls this BEFORE opening its write transaction, so a
+rejected template never touches the DB.
+
+Template shape (dict, e.g. parsed from the router's JSON):
+
+    {
+      "topics": [
+        {
+          "id": "daily-digest",
+          "title": "Daily digest",
+          "objective": "…",                 # optional
+          "delivery": "deliver",            # topic-level default; 'merge' if absent
+          "tasks": [
+            {"id": "gen", "title": "…", "prompt": "…",
+             "role": "researcher", "model": "sonnet",
+             "verify_cmd": null, "deps": []}
+          ]
+        }
+      ]
+    }
+"""
+from __future__ import annotations
+
+_VALID_ROLES = frozenset({"coder", "planner", "researcher"})
+_VALID_DELIVERY = frozenset({"merge", "deliver"})
+
+
+class LoopTemplateError(ValueError):
+    """A loop template violates the deterministic partition/scope rules."""
+
+
+def _task_signature(task: dict, topic_delivery: str) -> tuple:
+    """The (role, model, delivery) tuple a member task belongs to. ``delivery``
+    falls back to the topic-level default when the task omits it."""
+    role = task.get("role") or "coder"
+    model = task.get("model")  # None is a legitimate 'unpinned' value in V1
+    delivery = task.get("delivery") or topic_delivery
+    return (role, model, delivery)
+
+
+def validate_loop_template(template: dict) -> dict:
+    """Validate + normalise a loop template for V1 (single-topic loops).
+
+    Returns a normalised template ``{"topics": [<one topic>]}`` where the topic
+    carries the shared ``role``/``delivery`` and every task carries an explicit
+    ``role``/``model``/``delivery``/``deps``. Raises ``LoopTemplateError`` (never
+    a bare ValueError from deep inside) on any partition/scope violation.
+    """
+    if not isinstance(template, dict):
+        raise LoopTemplateError("template must be a dict")
+    topics = template.get("topics")
+    if not isinstance(topics, list) or not topics:
+        raise LoopTemplateError("template must contain a non-empty 'topics' list")
+    if len(topics) != 1:
+        raise LoopTemplateError(
+            f"V1 supports single-topic loops only; got {len(topics)} topics "
+            f"(multi-topic decomposition is a V2 concern)"
+        )
+    topic = topics[0]
+    if not isinstance(topic, dict) or not topic.get("id"):
+        raise LoopTemplateError("topic must be a dict with a non-empty 'id'")
+    if not topic.get("title"):
+        raise LoopTemplateError(f"topic {topic['id']!r} must have a 'title'")
+
+    topic_delivery = topic.get("delivery") or "merge"
+    if topic_delivery not in _VALID_DELIVERY:
+        raise LoopTemplateError(
+            f"topic {topic['id']!r} delivery {topic_delivery!r} invalid "
+            f"(expected one of {sorted(_VALID_DELIVERY)})"
+        )
+
+    tasks = topic.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise LoopTemplateError(f"topic {topic['id']!r} has no member tasks")
+
+    sigs = set()
+    for task in tasks:
+        if not isinstance(task, dict) or not task.get("id"):
+            raise LoopTemplateError(
+                f"topic {topic['id']!r} has a task with no 'id'"
+            )
+        role = task.get("role") or "coder"
+        if role not in _VALID_ROLES:
+            raise LoopTemplateError(
+                f"task {task['id']!r} role {role!r} invalid "
+                f"(expected one of {sorted(_VALID_ROLES)})"
+            )
+        delivery = task.get("delivery") or topic_delivery
+        if delivery not in _VALID_DELIVERY:
+            raise LoopTemplateError(
+                f"task {task['id']!r} delivery {delivery!r} invalid "
+                f"(expected one of {sorted(_VALID_DELIVERY)})"
+            )
+        sigs.add(_task_signature(task, topic_delivery))
+
+    if len(sigs) != 1:
+        raise LoopTemplateError(
+            f"topic {topic['id']!r} mixes (role, model, delivery) across its "
+            f"member tasks: {sorted(sigs)} — same (role, model) belongs in ONE "
+            f"topic; differing signatures require SEPARATE topics (V2)."
+        )
+    role, model, delivery = next(iter(sigs))
+
+    norm_tasks = []
+    for task in tasks:
+        norm_tasks.append({
+            "id": task["id"],
+            "title": task.get("title") or task["id"],
+            "prompt": task.get("prompt") or "",
+            "role": role,
+            "model": model,
+            "delivery": delivery,
+            "verify_cmd": task.get("verify_cmd"),
+            "deps": list(task.get("deps") or []),
+        })
+    norm_topic = {
+        "id": topic["id"],
+        "title": topic["title"],
+        "objective": topic.get("objective") or "",
+        "role": role,
+        "delivery": delivery,
+        "tasks": norm_tasks,
+    }
+    return {"topics": [norm_topic]}

--- a/src/juggle_loop_template_validator.py
+++ b/src/juggle_loop_template_validator.py
@@ -129,6 +129,21 @@ def validate_loop_template(template: dict) -> dict:
             "verify_cmd": task.get("verify_cmd"),
             "deps": list(task.get("deps") or []),
         })
+
+    # Dep closure: every dep must reference a sibling member task (never a foreign
+    # id, never itself). replace_edges uses INSERT OR IGNORE with no FK check, so a
+    # dangling dep edge would silently wedge a task at never-'deps_ready'. The
+    # validator is the deterministic gate — reject it here, not at run time.
+    member_ids = {tk["id"] for tk in norm_tasks}
+    for tk in norm_tasks:
+        for dep in tk["deps"]:
+            if dep == tk["id"]:
+                raise LoopTemplateError(f"task {tk['id']!r} depends on itself")
+            if dep not in member_ids:
+                raise LoopTemplateError(
+                    f"task {tk['id']!r} dep {dep!r} is not a member task of topic "
+                    f"{topic['id']!r}"
+                )
     norm_topic = {
         "id": topic["id"],
         "title": topic["title"],

--- a/src/juggle_watchdog_daemon.py
+++ b/src/juggle_watchdog_daemon.py
@@ -321,14 +321,10 @@ def _poll_once(db: JuggleDB, mgr: JuggleTmuxManager) -> None:
     except Exception:
         _log.exception("Watchdog: daemon reaper tick failed — continuing")
 
-    # Graph claim-dispatch tick (autopilot Phase 2, DA B4/M1) — guarded so a bug never downs the daemon.
-    try:
-        from juggle_graph_dispatch import graph_tick
-        graph_tick(db, mgr)
-        from juggle_graph_repair import run_tick_sweeps  # T1c: TTL + notif reconcile
-        run_tick_sweeps(db)
-    except Exception:
-        _log.exception("Watchdog: graph dispatch tick failed — continuing")
+    # Graph claim-dispatch + loop-fire tick (extracted to juggle_watchdog_loop_tick
+    # for the daemon LOC budget) — guarded internally so a bug never downs the tick.
+    from juggle_watchdog_loop_tick import run_graph_and_loop_ticks
+    run_graph_and_loop_ticks(db, mgr, session_id)
     from juggle_topic_reconcile import tick_sweep as _ts  # F5 conversation-topic sweep
     _ts(db)
 

--- a/src/juggle_watchdog_loop_tick.py
+++ b/src/juggle_watchdog_loop_tick.py
@@ -25,3 +25,12 @@ def run_graph_and_loop_ticks(db, mgr, session_id: str) -> None:
         run_tick_sweeps(db)
     except Exception:
         _log.exception("Watchdog: graph dispatch tick failed — continuing")
+
+    # Loop-fire tick (loop-entity Phase 5): fire every due active loop (CAS-safe,
+    # overlap-skip, circuit-breaker). Guarded so a loop bug never downs the tick.
+    try:
+        from juggle_loop_fire import fire_due_loops
+
+        fire_due_loops(db, session_id)
+    except Exception:
+        _log.exception("Watchdog: loop-fire tick failed — continuing")

--- a/src/juggle_watchdog_loop_tick.py
+++ b/src/juggle_watchdog_loop_tick.py
@@ -1,0 +1,27 @@
+"""juggle_watchdog_loop_tick — graph-dispatch tick substep extracted from the
+watchdog daemon.
+
+Extraction rationale (architecture LOC gate): ``juggle_watchdog_daemon`` sits at
+its 487-line allowlist budget, so the graph-dispatch tick block was lifted here to
+free budget (and to give the co-located loop-fire step a home). Behaviour-neutral —
+the daemon now calls ``run_graph_and_loop_ticks`` in the same tick position.
+"""
+from __future__ import annotations
+
+import logging
+
+_log = logging.getLogger("juggle.watchdog.loop_tick")
+
+
+def run_graph_and_loop_ticks(db, mgr, session_id: str) -> None:
+    """Graph claim-dispatch tick (autopilot Phase 2). Guarded so a bug never downs
+    the daemon."""
+    try:
+        from juggle_graph_dispatch import graph_tick
+
+        graph_tick(db, mgr)
+        from juggle_graph_repair import run_tick_sweeps  # T1c: TTL + notif reconcile
+
+        run_tick_sweeps(db)
+    except Exception:
+        _log.exception("Watchdog: graph dispatch tick failed — continuing")

--- a/tests/test_delivered_terminal.py
+++ b/tests/test_delivered_terminal.py
@@ -1,0 +1,167 @@
+"""Phase-3 pins for the `delivered` success-terminal (loop-entity V1,
+2026-07-04). A delivery='deliver' topic reaches a NEW terminal-SUCCESS state
+`delivered` with NO merged_sha, while delivery='merge' keeps the EXISTING
+verified⟺merged gate byte-for-byte. `delivered` must be accepted everywhere
+`verified` is treated as terminal-success.
+
+Incidents pinned:
+  * LEAD FINDING (critique 2026-07-04): a deliver topic that can never go
+    terminal wedges the loop iteration → §9 overlap-skip then skips every future
+    fire forever = silent permanent loop death. The completion gate + the
+    mark-completion seam must map deliver→delivered.
+  * verified⟺merged invariant (graph_guards.topic_is_merged): a merge topic with
+    no merged_sha is STILL refused. `delivered` must never forge that proof.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from juggle_db import JuggleDB  # noqa: E402
+from dbops import db_graph as g  # noqa: E402
+from dbops import db_topics as t  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "delivered.db"))
+    d.init_db()
+    return d
+
+
+def _topic(db, tid, project="INBOX"):
+    t.create_topic(db, topic_id=tid, project_id=project, title=f"Topic {tid}")
+
+
+def _task(db, nid, topic_id):
+    g.create_task(db, task_id=nid, project_id="INBOX", title=nid, prompt=f"do {nid}")
+    g.set_task_topic(db, nid, topic_id)
+    g.task_transition(db, nid, "deps_ready")
+    g.task_transition(db, nid, "claim")
+    g.task_transition(db, nid, "dispatch")
+    g.task_transition(db, nid, "integrate_start")
+    g.task_transition(db, nid, "integrate_ok")
+
+
+def _set_delivery(db, tid, delivery):
+    with db._connect() as c:
+        c.execute("UPDATE nodes SET delivery=? WHERE id=? AND kind='topic'",
+                  (delivery, tid))
+        c.commit()
+
+
+# ── The two load-bearing contract pins ──────────────────────────────────────────
+def test_deliver_topic_reaches_delivered_not_wedged(db):
+    """LOAD-BEARING (LEAD FINDING). A delivery='deliver' topic with NO branch/repo
+    completes to 'delivered' and does NOT stall pre-verified. RED on pre-Phase-3
+    code: mark_topic_completion walks integrate_ok→verified, the merged_sha gate
+    refuses (UnmergedVerifyRefused), the topic wedges → the loop dies silently."""
+    _topic(db, "D1")
+    _task(db, "n1", "D1")
+    _set_delivery(db, "D1", "deliver")
+
+    state = t.mark_topic_completion(db, "D1", integrate_ok=True, verify_ok=True)
+
+    assert state == "delivered"
+    topic = t.get_topic(db, "D1")
+    assert topic["state"] == "delivered"
+    assert not topic.get("merged_sha")
+
+
+def test_merge_topic_still_requires_merged_sha(db):
+    """INVARIANT: delivery='merge' (the default) is UNCHANGED — a topic with no
+    merged_sha is STILL refused verified (verified⟺merged, graph_guards.
+    topic_is_merged). Adding 'delivered' must not relax this gate."""
+    _topic(db, "M1")
+    _task(db, "n2", "M1")
+
+    with pytest.raises(t.UnmergedVerifyRefused):
+        t.mark_topic_completion(db, "M1", integrate_ok=True, verify_ok=True)
+
+    assert t.get_topic(db, "M1")["state"] == "integrating"
+
+
+def test_delivered_never_sets_merged_sha(db):
+    """A completed deliver topic leaves merged_sha NULL — deliver must not forge
+    the merge proof."""
+    _topic(db, "D2")
+    _task(db, "n3", "D2")
+    _set_delivery(db, "D2", "deliver")
+
+    t.mark_topic_completion(db, "D2", integrate_ok=True, verify_ok=True)
+
+    assert not t.get_topic(db, "D2").get("merged_sha")
+
+
+# ── Terminal-success consumers must count `delivered` as done ────────────────────
+def test_delivered_counts_as_terminal_success():
+    """The real terminal-success consumers audited for Phase 3 all count a
+    `delivered` node as done, so a delivered loop never reads perpetually
+    N/M-incomplete. RED on pre-Phase-3 code (progress counts only 'verified';
+    the canonical sets lack 'delivered')."""
+    from dbops import terminal_states as ts
+    from juggle_graph_status import counts_from_states, format_progress
+
+    # progress % (juggle_graph_status) — the cockpit "3/14 done" numerator
+    counts = counts_from_states(["delivered", "verified", "open"])
+    assert counts["verified"] == 2  # both success-terminals count as done
+    assert format_progress(counts).startswith("2/3 done")
+
+    # reconcile topic-rollup completion set + topic-done derivation + completion gate
+    assert "delivered" in ts.COMPLETION_TERMINAL_STATES  # db_topics_reconcile
+    assert "delivered" in ts.MERGED_TERMINAL_STATES      # juggle_topic_derive
+    assert "delivered" in ts.MERGED_DONE_STATES          # cockpit_tree glyph
+    assert "delivered" in ts.TASK_TERMINAL_STATES        # completion gate
+    assert "delivered" in ts.TERMINAL_STATES
+    assert ts.is_success_terminal("delivered")
+    # delivered is NOT in-flight (learnings-rollup inverse relies on this)
+    assert "delivered" not in ts.IN_FLIGHT_STATES
+    assert not ts.is_in_flight("delivered")
+
+
+def test_completion_gate_accepts_delivered_task(db):
+    """LEAD-FINDING guard: check_topic_completion_gate must NOT refuse a topic
+    whose member task is 'delivered' (delivered ∈ TASK_TERMINAL_STATES). RED on
+    pre-Phase-3 code: a task cannot even reach 'delivered' (no deliver_ok edge)."""
+    from juggle_cmd_agents_graph_topics import check_topic_completion_gate
+
+    _topic(db, "G1")
+    g.create_task(db, task_id="gk", project_id="INBOX", title="gk", prompt="x")
+    g.set_task_topic(db, "gk", "G1")
+    for ev in ("deps_ready", "claim", "dispatch", "integrate_start", "deliver_ok"):
+        g.task_transition(db, "gk", ev)
+    assert t.get_topic(db, "G1") is not None
+    thread_id = db.create_thread(topic="w", session_id="s")
+    t.set_topic_thread(db, "G1", thread_id)
+
+    assert check_topic_completion_gate(db, thread_id) is None
+
+
+# ── Node-machine: delivered is reachable and not a dead-end ──────────────────────
+def test_node_machine_delivered_has_legal_exits():
+    """`delivered` has an incoming deliver_ok edge and the same exits as verified
+    (g1_pass→done, archive→archived, reopen→open) — never a dead-end state."""
+    from dbops.db_node_machine import node_transition
+
+    assert node_transition("integrating", "deliver_ok", "task") == "delivered"
+    assert node_transition("delivered", "g1_pass", "task") == "done"
+    assert node_transition("delivered", "archive", "task") == "archived"
+    assert node_transition("delivered", "reopen", "task") == "open"
+
+
+def test_deliver_completion_is_idempotent(db):
+    """A racing double-completion on an already-'delivered' topic must not raise
+    (mirrors the already-verified idempotency guard, Bug I 2026-06-11)."""
+    _topic(db, "D3")
+    _task(db, "n4", "D3")
+    _set_delivery(db, "D3", "deliver")
+    t.mark_topic_completion(db, "D3", integrate_ok=True, verify_ok=True)
+
+    state = t.mark_topic_completion(db, "D3", integrate_ok=True, verify_ok=True)
+
+    assert state == "delivered"

--- a/tests/test_dispatch_role.py
+++ b/tests/test_dispatch_role.py
@@ -1,0 +1,201 @@
+"""Tests for loop-entity Phase 2 — per-node role dispatch.
+
+The watchdog dispatcher used to send EVERY graph node as a hardcoded
+``TASK_ROLE="coder"`` (juggle_graph_dispatch.py). Phase 2 resolves the role
+from the node's ``nodes.role`` column (Phase-1, DEFAULT 'coder') so a
+``role='researcher'`` node claims a researcher pane and runs read-only in place
+(NO worktree), while ``coder``/``planner`` nodes are unchanged (worktree as
+today) and legacy NULL-role nodes still resolve 'coder'.
+
+The send-path worktree gate (juggle_dispatch_worktree_context.build_worktree_context,
+the block send_task_to_agent actually calls) already early-exits for any role
+outside {coder, planner}; Phase 2 is what makes the RIGHT role reach it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import juggle_cmd_agents_common as _com  # noqa: E402
+import juggle_graph_dispatch as gd  # noqa: E402
+from dbops.schema import _now  # noqa: E402
+from juggle_db import JuggleDB  # noqa: E402
+from juggle_dispatch_worktree_context import build_worktree_context  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "role.db"))
+    d.init_db()
+    return d
+
+
+def _seed_node(db, nid, *, role, kind="topic", project="INBOX"):
+    """Insert a node with an explicit role."""
+    now = _now()
+    with db._connect() as conn:
+        conn.execute(
+            "INSERT INTO nodes (id, kind, title, objective, state, project_id, "
+            "role, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (nid, kind, nid, "", "ready", project, role, now, now),
+        )
+        conn.commit()
+
+
+def _seed_node_default_role(db, nid, kind="topic", project="INBOX"):
+    """Insert a node WITHOUT specifying role — it takes nodes.role DEFAULT
+    'coder' (how a legacy/existing node reads after the Phase-1 ALTER backfill)."""
+    now = _now()
+    with db._connect() as conn:
+        conn.execute(
+            "INSERT INTO nodes (id, kind, title, objective, state, project_id, "
+            "created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+            (nid, kind, nid, "", "ready", project, now, now),
+        )
+        conn.commit()
+
+
+def _forwarded_role(db, monkeypatch, node) -> str:
+    """The role _dispatch_via_pool forwards to dispatch_node for ``node``."""
+    import juggle_dispatch_core as _core
+
+    captured: dict = {}
+
+    def spy(db_, tid_, prompt_, task_, *, role="coder", model=None):
+        captured["role"] = role
+
+    monkeypatch.setattr(_core, "dispatch_node", spy)
+    tid = db.create_thread("x", session_id="s")
+    gd._dispatch_via_pool(db, tid, "prompt", node)
+    return captured["role"]
+
+
+def _fake_mgr(pane_id="%fake"):
+    mgr = MagicMock()
+    mgr.wait_for_ready_to_paste.return_value = True
+    mgr._run_tmux.return_value = MagicMock(returncode=0, stdout="")
+    mgr.verify_pane.return_value = True
+    return mgr
+
+
+# ── role resolution reaches the dispatch layer ────────────────────────────────
+
+
+def test_researcher_node_gets_no_worktree(db, monkeypatch):
+    """Phase 2: a role='researcher' node dispatches as 'researcher' and the
+    send-path worktree gate produces NO worktree (early-exit). RED on pre-Phase-2
+    code: _dispatch_via_pool forwarded the hardcoded 'coder', so every node got a
+    worktree (facts completion §5 — researcher must run read-only in place)."""
+    _seed_node(db, "T-r", role="researcher")
+    assert _forwarded_role(db, monkeypatch, {"id": "T-r"}) == "researcher"
+
+    # Downstream gate lock: researcher never triggers worktree creation.
+    created: list = []
+    monkeypatch.setattr(
+        _com, "_create_worktree",
+        lambda *a, **k: (created.append(1), (True, "/wt", "br", "ok"))[1],
+    )
+    tid = db.create_thread("r", session_id="s")
+    ctx = build_worktree_context(
+        db, role="researcher", agent={"repo_path": "/repo"}, pane_id="%p",
+        thread_id=tid, allow_main=False, worktree_path_override=None,
+        worktree_branch_override=None, main_repo_override=None,
+        default_worktree_root="/tmp",
+    )
+    assert ctx == ""
+    assert created == [], "researcher must not create a worktree"
+    assert (db.get_thread(tid) or {}).get("worktree_path") in (None, "")
+
+
+def test_coder_node_unchanged_gets_worktree(db, monkeypatch):
+    """REGRESSION PIN (Phase 2): a role='coder' node is UNCHANGED — it dispatches
+    as 'coder' and the send-path gate creates/attaches an isolated worktree,
+    exactly as before Phase 2. Zero regression for existing coder graphs."""
+    _seed_node(db, "T-c", role="coder")
+    assert _forwarded_role(db, monkeypatch, {"id": "T-c"}) == "coder"
+
+    created: list = []
+    monkeypatch.setattr(
+        _com, "_create_worktree",
+        lambda *a, **k: (created.append(1), (True, "/wt/c", "cyc_c", "made wt"))[1],
+    )
+    monkeypatch.setattr(
+        "juggle_repo_binding.resolve_worktree_base", lambda *a, **k: "/repo",
+    )
+    tid = db.create_thread("c", session_id="s")
+    ctx = build_worktree_context(
+        db, role="coder", agent={"repo_path": "/repo"}, pane_id="%p",
+        thread_id=tid, allow_main=False, worktree_path_override=None,
+        worktree_branch_override=None, main_repo_override=None,
+        default_worktree_root="/tmp",
+    )
+    assert created == [1], "coder must create a worktree"
+    assert "## Working Directory" in ctx
+    assert (db.get_thread(tid) or {}).get("worktree_path") == "/wt/c"
+
+
+def test_planner_node_gets_worktree(db, monkeypatch):
+    """Phase 2: a role='planner' node dispatches as 'planner' and (parity with
+    coder) gets a worktree — the gate admits {coder, planner}."""
+    _seed_node(db, "T-p", role="planner")
+    assert _forwarded_role(db, monkeypatch, {"id": "T-p"}) == "planner"
+
+    created: list = []
+    monkeypatch.setattr(
+        _com, "_create_worktree",
+        lambda *a, **k: (created.append(1), (True, "/wt/p", "cyc_p", "made wt"))[1],
+    )
+    monkeypatch.setattr(
+        "juggle_repo_binding.resolve_worktree_base", lambda *a, **k: "/repo",
+    )
+    tid = db.create_thread("p", session_id="s")
+    ctx = build_worktree_context(
+        db, role="planner", agent={"repo_path": "/repo"}, pane_id="%p",
+        thread_id=tid, allow_main=False, worktree_path_override=None,
+        worktree_branch_override=None, main_repo_override=None,
+        default_worktree_root="/tmp",
+    )
+    assert created == [1] and "## Working Directory" in ctx
+
+
+def test_dispatch_role_defaults_coder_when_unset(db, monkeypatch):
+    """Phase 2: a legacy node carrying the nodes.role DEFAULT 'coder' (and a node
+    absent from the DB) resolves 'coder' — existing graphs are unaffected."""
+    _seed_node_default_role(db, "T-null")
+    assert gd._resolve_dispatch_role(db, {"id": "T-null"}) == "coder"
+    # Absent id → still coder (no crash), and an empty/None node → coder.
+    assert gd._resolve_dispatch_role(db, {"id": "does-not-exist"}) == "coder"
+    assert gd._resolve_dispatch_role(db, None) == "coder"
+    assert _forwarded_role(db, monkeypatch, {"id": "T-null"}) == "coder"
+
+
+def test_resolve_role_prefers_hydrated_dict_value(db):
+    """A caller that already hydrated 'role' onto the node dict wins without a
+    DB read (forward-compat for hydrated topic/task dicts)."""
+    assert gd._resolve_dispatch_role(db, {"id": "unseeded", "role": "researcher"}) == "researcher"
+
+
+# ── agent pool claims the matching role ───────────────────────────────────────
+
+
+def test_acquire_agent_matches_role(db, monkeypatch):
+    """Phase 2 pane match (agent-pool facts §4): a researcher dispatch claims a
+    researcher-role idle pane, not a coder pane — acquire_agent filters idle
+    candidates by the passed role."""
+    from juggle_dispatch_core import acquire_agent
+
+    monkeypatch.setattr("juggle_tmux._spawn_repo_path", lambda: "")
+    coder_id = db.create_agent(role="coder", pane_id="%c", harness="claude", repo_path="")
+    research_id = db.create_agent(role="researcher", pane_id="%r", harness="claude", repo_path="")
+    tid = db.create_thread("t", session_id="s")
+
+    agent = acquire_agent(db, tid, role="researcher", _mgr=_fake_mgr())
+
+    assert agent["id"] == research_id, "researcher dispatch must claim the researcher pane"
+    assert agent["role"] == "researcher"
+    assert db.get_agent(coder_id)["status"] == "idle", "coder pane must stay idle"

--- a/tests/test_event_routing.py
+++ b/tests/test_event_routing.py
@@ -8,12 +8,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from dbops import event_kinds as ek
 
 
-def test_nineteen_kinds_defined():
+def test_kinds_defined():
     """irl-envelope T2 adds integrate_failed + machinery_error to T1a's 12;
     irl-retry T3 adds repair_exhausted; irl-repair T4 adds repair_dispatched;
     df-monitor-dispatch adds dispatch_failed + running_orphan; gl-rollup adds
-    learnings_rollup."""
-    assert len(ek.ALL_KINDS) == 19
+    learnings_rollup; loop-entity Phase 5 adds loop_iteration_failed + loop_paused."""
+    assert len(ek.ALL_KINDS) == 21
+
+
+def test_loop_failure_kinds_route_orchestrator():
+    """loop-entity Phase 5 (2026-07-04): a loop iteration failure / breaker pause
+    pushes the orchestrator immediately (derived routing, pushable) — a loop failure
+    is machinery/judgment per the CLAUDE.md triage ladder, never DB-row-only."""
+    for kind in (ek.LOOP_ITERATION_FAILED, ek.LOOP_PAUSED):
+        assert ek.handled_by_for_kind(kind) == "orchestrator"
+        assert ek.is_pushable(ek.handled_by_for_kind(kind))
 
 
 def test_dispatch_failure_kinds_default_watchdog_overridable_to_orchestrator():

--- a/tests/test_loop_create.py
+++ b/tests/test_loop_create.py
@@ -145,9 +145,14 @@ def test_loop_create_atomic_rollback_on_graph_failure(db, monkeypatch):
     """§Axis-5 LOAD-BEARING: a failure mid-create (after the project + topic are
     written) rolls the WHOLE transaction back — NO projects row, NO loops row, NO
     orphan nodes. A half-created kind='loop' project must never claim a P-slot."""
+    # create_task is now called through the shared juggle_loop_instantiate writer
+    # (Phase-5 refactor: one iteration-materialization seam for create + re-fire).
+    # Inject the mid-create failure at that new seam — same rollback behavior pinned.
+    import juggle_loop_instantiate as li
+
     def _boom(*a, **k):
         raise RuntimeError("injected mid-create failure")
-    monkeypatch.setattr(lc.db_graph, "create_task", _boom)
+    monkeypatch.setattr(li.db_graph, "create_task", _boom)
 
     with pytest.raises(RuntimeError, match="injected"):
         create_loop_atomic(db, template=_single_topic_template(), cadence="every 1h")

--- a/tests/test_loop_create.py
+++ b/tests/test_loop_create.py
@@ -1,0 +1,158 @@
+"""Phase-4 pins: transactional single-topic loop create + partition validator
+(loop-entity V1, 2026-07-04).
+
+Two critique axes are pinned here:
+  * §Axis-5 (atomic create): creating a loop (allocate L-id, kind='loop' project,
+    load the single-topic template graph, insert the loop row with next_run) is ONE
+    DB transaction — any step failing rolls the WHOLE thing back so NO half-created
+    kind='loop' project can claim a P-slot and NO orphan loop/graph row survives.
+  * §Axis-4 (deterministic partition): the "same (role, model, delivery) → one
+    topic" rule is enforced by CODE at create time, never trusted from the LLM. For
+    V1 the validator additionally rejects any multi-topic template.
+
+Plus the §11 bullet-2 guard: a kind='loop' project must NOT leak into the arming /
+P-slot feeds before the V2 render band exists.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from juggle_db import JuggleDB  # noqa: E402
+import juggle_cmd_loop_create as lc  # noqa: E402
+from juggle_cmd_loop_create import create_loop_atomic, compute_next_run  # noqa: E402
+from juggle_loop_template_validator import (  # noqa: E402
+    LoopTemplateError,
+    validate_loop_template,
+)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "loop-create.db"))
+    d.init_db()
+    return d
+
+
+def _single_topic_template(delivery="deliver", role="researcher", ntasks=1):
+    tasks = [
+        {"id": f"t{i}", "title": f"task {i}", "prompt": f"do {i}",
+         "role": role, "model": "sonnet", "verify_cmd": None, "deps": []}
+        for i in range(ntasks)
+    ]
+    return {"topics": [{
+        "id": "digest", "title": "Daily digest", "objective": "obj",
+        "delivery": delivery, "tasks": tasks,
+    }]}
+
+
+# ── Deterministic partition validator (§Axis-4) ─────────────────────────────────
+def test_validator_rejects_multi_topic_in_v1():
+    """V1 single-topic scope guard: a 2-topic template is rejected deterministically."""
+    tmpl = {"topics": [
+        {"id": "a", "title": "A", "delivery": "merge",
+         "tasks": [{"id": "x", "title": "x", "prompt": "p", "role": "coder"}]},
+        {"id": "b", "title": "B", "delivery": "merge",
+         "tasks": [{"id": "y", "title": "y", "prompt": "p", "role": "coder"}]},
+    ]}
+    with pytest.raises(LoopTemplateError, match="single-topic"):
+        validate_loop_template(tmpl)
+
+
+def test_validator_rejects_mixed_role_topic():
+    """§Axis-4: a topic mixing researcher+coder member tasks is rejected in code —
+    the partition rule is NOT trusted from raw LLM output."""
+    tmpl = {"topics": [{
+        "id": "a", "title": "A", "delivery": "merge",
+        "tasks": [
+            {"id": "x", "title": "x", "prompt": "p", "role": "researcher"},
+            {"id": "y", "title": "y", "prompt": "p", "role": "coder"},
+        ],
+    }]}
+    with pytest.raises(LoopTemplateError, match="mixes"):
+        validate_loop_template(tmpl)
+
+
+def test_validator_normalizes_single_topic():
+    """A valid single-topic template lifts the shared role/delivery onto the topic
+    and fills each task's role/delivery/deps."""
+    norm = validate_loop_template(_single_topic_template(delivery="deliver",
+                                                         role="researcher", ntasks=2))
+    topic = norm["topics"][0]
+    assert topic["role"] == "researcher"
+    assert topic["delivery"] == "deliver"
+    assert all(tk["role"] == "researcher" and tk["delivery"] == "deliver"
+               for tk in topic["tasks"])
+
+
+def test_compute_next_run_from_cadence():
+    """next_run is derived from the cadence string; an unparseable cadence is
+    fail-loud (a loop with no timer would silently never fire)."""
+    from datetime import datetime
+    now = datetime(2026, 7, 4, 8, 0, 0)
+    assert compute_next_run("every 15m", now).startswith("2026-07-04T08:15")
+    assert compute_next_run("daily at 09:30", now).startswith("2026-07-04T09:30")
+    with pytest.raises(LoopTemplateError):
+        compute_next_run("whenever", now)
+
+
+# ── Atomic create (§Axis-5) ─────────────────────────────────────────────────────
+def test_loop_project_has_kind_loop(db):
+    r = create_loop_atomic(db, template=_single_topic_template(), cadence="every 1h")
+    proj = db.get_project(r["project_id"])
+    assert proj["kind"] == "loop"
+
+
+def test_loop_create_sets_next_run(db):
+    r = create_loop_atomic(db, template=_single_topic_template(), cadence="every 30m")
+    loop = db.get_loop(r["loop_id"])
+    assert loop["next_run"] == r["next_run"]
+    assert loop["next_run"]  # populated, not NULL
+
+
+def test_run_seq_namespaced_node_ids(db):
+    """Created node ids carry the <L#>-r0- prefix (collision guard vs the
+    guarded-upsert refusal on re-fire)."""
+    r = create_loop_atomic(db, template=_single_topic_template(ntasks=2),
+                           cadence="every 1h")
+    prefix = f"{r['loop_id']}-r0-"
+    assert r["topic_id"].startswith(prefix)
+    assert all(nid.startswith(prefix) for nid in r["node_ids"])
+
+
+def test_loop_create_atomic_rollback_on_graph_failure(db, monkeypatch):
+    """§Axis-5 LOAD-BEARING: a failure mid-create (after the project + topic are
+    written) rolls the WHOLE transaction back — NO projects row, NO loops row, NO
+    orphan nodes. A half-created kind='loop' project must never claim a P-slot."""
+    def _boom(*a, **k):
+        raise RuntimeError("injected mid-create failure")
+    monkeypatch.setattr(lc.db_graph, "create_task", _boom)
+
+    with pytest.raises(RuntimeError, match="injected"):
+        create_loop_atomic(db, template=_single_topic_template(), cadence="every 1h")
+
+    with db._connect() as c:
+        assert c.execute("SELECT COUNT(*) FROM projects WHERE kind='loop'").fetchone()[0] == 0
+        assert c.execute("SELECT COUNT(*) FROM loops").fetchone()[0] == 0
+        assert c.execute("SELECT COUNT(*) FROM nodes WHERE id LIKE '%-r0-%'").fetchone()[0] == 0
+
+
+def test_loop_project_excluded_from_arming_feeds(db):
+    """§11 bullet-2 guard: a kind='loop' project must NOT surface in the arming /
+    P-slot feeds (list_projects default + get_active_projects), while a normal
+    project still does. Closes the leak before the V2 render band lands."""
+    normal = db.create_project(name="normal", objective="o")
+    r = create_loop_atomic(db, template=_single_topic_template(), cadence="every 1h")
+
+    active_ids = {p["id"] for p in db.get_active_projects()}
+    listed_ids = {p["id"] for p in db.list_projects()}
+    assert r["project_id"] not in active_ids
+    assert r["project_id"] not in listed_ids
+    assert normal in active_ids and normal in listed_ids  # normal project unaffected
+    # include_archived='give me everything' still sees the loop (doctor migrate path)
+    assert r["project_id"] in {p["id"] for p in db.list_projects(include_archived=True)}

--- a/tests/test_loop_create.py
+++ b/tests/test_loop_create.py
@@ -90,15 +90,31 @@ def test_validator_normalizes_single_topic():
                for tk in topic["tasks"])
 
 
+def test_validator_rejects_dangling_and_self_deps():
+    """Dep closure (code-review #4): a dep to a non-member id or to itself is
+    rejected — a dangling dep edge would silently wedge the task."""
+    tmpl = _single_topic_template(ntasks=2)
+    tmpl["topics"][0]["tasks"][1]["deps"] = ["nonexistent"]
+    with pytest.raises(LoopTemplateError, match="not a member task"):
+        validate_loop_template(tmpl)
+    tmpl2 = _single_topic_template(ntasks=1)
+    tmpl2["topics"][0]["tasks"][0]["deps"] = [tmpl2["topics"][0]["tasks"][0]["id"]]
+    with pytest.raises(LoopTemplateError, match="depends on itself"):
+        validate_loop_template(tmpl2)
+
+
 def test_compute_next_run_from_cadence():
-    """next_run is derived from the cadence string; an unparseable cadence is
-    fail-loud (a loop with no timer would silently never fire)."""
+    """next_run is derived from the cadence string; an unparseable cadence AND an
+    out-of-range daily time are both fail-loud LoopTemplateError (a loop with no
+    valid timer would silently never fire)."""
     from datetime import datetime
     now = datetime(2026, 7, 4, 8, 0, 0)
     assert compute_next_run("every 15m", now).startswith("2026-07-04T08:15")
     assert compute_next_run("daily at 09:30", now).startswith("2026-07-04T09:30")
     with pytest.raises(LoopTemplateError):
         compute_next_run("whenever", now)
+    with pytest.raises(LoopTemplateError, match="invalid time"):
+        compute_next_run("daily at 30:70", now)  # code-review #3: range guard
 
 
 # ── Atomic create (§Axis-5) ─────────────────────────────────────────────────────
@@ -156,3 +172,20 @@ def test_loop_project_excluded_from_arming_feeds(db):
     assert normal in active_ids and normal in listed_ids  # normal project unaffected
     # include_archived='give me everything' still sees the loop (doctor migrate path)
     assert r["project_id"] in {p["id"] for p in db.list_projects(include_archived=True)}
+    # match-profile synth feed excludes loops too (code-review #5)
+    db.mark_project_dirty(r["project_id"])
+    assert r["project_id"] not in {p["id"] for p in db.get_dirty_projects()}
+
+
+def test_loop_project_excluded_from_cockpit_render(db):
+    """code-review #2: the cockpit project-slot / DAG feeds must NOT render a
+    kind='loop' project (the plan's Phase-4 P-slot pin). A loop with a topic graph
+    produces no graph-DAG card."""
+    from juggle_cockpit_graph_dag import load_graph_dags
+
+    normal = db.create_project(name="normal", objective="o")
+    r = create_loop_atomic(db, template=_single_topic_template(), cadence="every 1h")
+    with db._connect() as conn:
+        dag_pids = {d.project_id for d in load_graph_dags(conn)}
+    assert r["project_id"] not in dag_pids
+    _ = normal  # a normal project with tasks WOULD render; loop must not

--- a/tests/test_loop_deliver_completion.py
+++ b/tests/test_loop_deliver_completion.py
@@ -1,0 +1,109 @@
+"""Phase-4 boundary #2 end-to-end pins (loop-entity V1, 2026-07-04).
+
+Phase 3 left the CALLER `mark_graph_topic` computing `all_verified =
+all(state=='verified')` and treating any non-'verified' terminal as a FAILURE
+(else-branch: propagate_topic_failure + bogus 'topic failed' HIGH item). Deliver
+loops did not exist yet. Now they do: a single-topic delivery='deliver' loop's
+member tasks reach 'delivered' (a success terminal), NOT 'verified'.
+
+Incident pinned (boundary #2): without the fix, a deliver loop driven through the
+REAL completion path (`mark_graph_topic`) passes verify_ok=False → mark_topic_
+completion walks verify_fail → the topic wedges at 'failed-verify' and a bogus
+failure is propagated → the loop iteration never reaches a success terminal →
+overlap-skip then kills the loop forever (LEAD FINDING). The completion caller must
+gate on the success-terminal SET so a deliver topic reaches 'delivered'.
+
+RED on pre-Phase-4 code: `mark_graph_topic` gates on the 'verified' literal, so the
+deliver topic lands in 'failed-verify', not 'delivered'.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from juggle_db import JuggleDB  # noqa: E402
+from dbops import db_graph as g  # noqa: E402
+from dbops import db_topics as t  # noqa: E402
+from juggle_cmd_agents_graph_topics import mark_graph_topic  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "loop-deliver.db"))
+    d.init_db()
+    return d
+
+
+def _topic(db, tid, delivery):
+    t.create_topic(db, topic_id=tid, project_id="INBOX", title=f"Topic {tid}")
+    with db._connect() as c:
+        c.execute("UPDATE nodes SET delivery=? WHERE id=? AND kind='topic'",
+                  (delivery, tid))
+        c.commit()
+
+
+def _member_task_to(db, nid, topic_id, final_event):
+    """Create a member task and drive it to its success terminal via the machine."""
+    g.create_task(db, task_id=nid, project_id="INBOX", title=nid, prompt=f"do {nid}")
+    g.set_task_topic(db, nid, topic_id)
+    for ev in ("deps_ready", "claim", "dispatch", "integrate_start", final_event):
+        g.task_transition(db, nid, ev)
+
+
+def _bound_thread(db, topic_id):
+    thread_id = db.create_thread(topic="loop-iter", session_id="s")
+    t.set_topic_thread(db, topic_id, thread_id)
+    return thread_id
+
+
+def test_single_topic_deliver_loop_completes_to_delivered(db):
+    """MANDATORY (boundary #2). A single-topic delivery='deliver' loop, driven
+    through the REAL completion caller `mark_graph_topic`, reaches 'delivered' —
+    NOT stuck pre-verified, NOT wedged at 'failed-verify'."""
+    _topic(db, "D1", "deliver")
+    _member_task_to(db, "d-task", "D1", "deliver_ok")  # member task → 'delivered'
+    assert t.get_topic(db, "D1")["state"] == "open"
+    thread_id = _bound_thread(db, "D1")
+
+    mark_graph_topic(db, thread_id, integrate_ok=True, handoff="digest ready",
+                     session_id="s", topic_id="D1")
+
+    topic = t.get_topic(db, "D1")
+    assert topic["state"] == "delivered"
+    assert not topic.get("merged_sha")  # deliver never forges a merge proof
+
+
+def test_deliver_loop_completion_files_no_failure_item(db):
+    """boundary #2 regression: a delivered topic must NOT trip the failure branch
+    (which would file a bogus 'topic failed (delivered)' HIGH action item)."""
+    _topic(db, "D2", "deliver")
+    _member_task_to(db, "d2-task", "D2", "deliver_ok")
+    thread_id = _bound_thread(db, "D2")
+
+    mark_graph_topic(db, thread_id, integrate_ok=True, handoff="ok",
+                     session_id="s", topic_id="D2")
+
+    failures = [i for i in db.get_open_action_items()
+                if (i.get("type") == "failure") and "D2" in (i.get("message") or "")]
+    assert failures == []
+
+
+def test_single_topic_merge_loop_still_completes_to_verified(db, monkeypatch):
+    """The merge equivalent is UNCHANGED: a delivery='merge' loop whose member
+    tasks are 'verified' reaches 'verified' through the same caller (merged_sha
+    gate faked green here — the gate itself is exercised by test_delivered_
+    terminal). Proves the success-terminal broadening did not break merge."""
+    monkeypatch.setattr(t, "_verified_allowed", lambda db_, tid: True)
+    _topic(db, "M1", "merge")
+    _member_task_to(db, "m-task", "M1", "integrate_ok")  # member task → 'verified'
+    thread_id = _bound_thread(db, "M1")
+
+    mark_graph_topic(db, thread_id, integrate_ok=True, handoff="landed",
+                     session_id="s", topic_id="M1")
+
+    assert t.get_topic(db, "M1")["state"] == "verified"

--- a/tests/test_loop_fire.py
+++ b/tests/test_loop_fire.py
@@ -65,8 +65,9 @@ def _make_loop(db, *, cadence="every 5m", max_cf=3, thread_id="T-loop", next_run
     res = create_loop_atomic(db, template=_template(), cadence=cadence,
                              max_consecutive_failures=max_cf)
     loop_id = res["loop_id"]
-    # V1 create leaves thread_id NULL + next_run in the future; drive it here so a
-    # failure surfaces on a real thread and the loop is due under a fixed `now`.
+    # create now binds the loop to its OWN thread; these tests pin a FIXED thread id
+    # + a PAST next_run so failures assert against a known thread and the loop is due
+    # under a fixed `now`. (The real-thread binding is pinned separately below.)
     with db._connect() as conn:
         conn.execute("UPDATE loops SET thread_id=?, next_run=? WHERE id=?",
                      (thread_id, next_run, loop_id))
@@ -164,6 +165,35 @@ def test_overlap_skip_escalates_after_k(db):
               if n["message"] and "wedged" in n["message"].lower()]
     assert pushed, "K overlap-skips must emit an escalation event"
     assert _iter_task_count(db, pid, loop_id, 1) == 0  # still never fired
+
+
+# ── Loop owns a real thread; failures surface ON it (not the orphan bucket) ─────
+def test_created_loop_has_thread_and_failure_item_lands_on_it(db):
+    """Review gap (2026-07-04): create_loop_atomic inserted thread_id=NULL, so a
+    failing iteration's HIGH action item landed in the null-thread ORPHAN bucket
+    instead of on the loop's OWN thread. A loop created via the REAL create path
+    must own a real thread, and its failure item must land ON that thread (the user
+    requirement: loop failures surface in the ACTION PANE on the loop)."""
+    res = create_loop_atomic(db, template=_template(), cadence="every 5m")
+    loop_id = res["loop_id"]
+    thread_id = db.get_loop(loop_id)["thread_id"]
+    assert thread_id, "created loop must own a real thread (not NULL/orphan)"
+    assert res["thread_id"] == thread_id  # create returns the bound thread
+
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "failed-verify")  # prior iteration failed
+    with db._connect() as conn:  # make it due — timer only; thread untouched
+        conn.execute("UPDATE loops SET next_run=? WHERE id=?", (PAST, loop_id))
+        conn.commit()
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+
+    items = db.get_open_action_items()
+    on_thread = [i for i in items if i["thread_id"] == thread_id]
+    assert on_thread, "failure HIGH action item must land on the loop's thread"
+    assert on_thread[0]["priority"] == "high"
+    assert not [i for i in items if i["thread_id"] is None], \
+        "no failure item may land in the null-thread ORPHAN bucket"
 
 
 # ── Never-swallow failure surfacing (LOAD-BEARING) ──────────────────────────────

--- a/tests/test_loop_fire.py
+++ b/tests/test_loop_fire.py
@@ -1,0 +1,292 @@
+"""Phase-5 pins: CAS-safe watchdog loop firing + failure circuit-breaker +
+never-swallow iteration-failure surfacing (loop-entity V1, 2026-07-04).
+
+Pinned invariants:
+  * §9 idempotent fire — a due loop instantiates its template exactly once per
+    window; a second tick in the same window does NOT re-fire (CAS advanced
+    next_run BEFORE instantiate).
+  * §Axis-7b crash safety — advancing next_run precedes instantiation, so a
+    crash/retry between the two never double-fires.
+  * §Axis-2 Objection B overlap policy — a prior iteration still in-flight makes
+    this fire SKIP + log; K consecutive skips ESCALATE (never skip-forever).
+  * user directive 2026-07-04 (LOAD-BEARING) — ANY iteration failure surfaces
+    through the single `surface_iteration_failure` choke point that NEVER
+    swallows: (a) a notifications_v2 event carrying the ACTUAL non-empty error,
+    (b) a HIGH action item on the loop's thread, (c) an orchestrator-routed
+    LOOP_ITERATION_FAILED push. A single failure does all three; the breaker
+    pause layers on REPEATED failure.
+  * §10b runaway control — N consecutive failed iterations pause the loop +
+    escalate; a good iteration resets the consecutive counter.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from juggle_db import JuggleDB  # noqa: E402
+from juggle_cmd_loop_create import create_loop_atomic  # noqa: E402
+import juggle_loop_fire as lf  # noqa: E402
+from dbops import event_kinds as ek  # noqa: E402
+
+SESSION = "sess-loop-fire"
+PAST = "2020-01-01T00:00:00+00:00"
+NOW = "2020-01-01T00:02:00+00:00"  # between PAST and PAST+5m — due exactly once
+
+
+@pytest.fixture(autouse=True)
+def _reset_skips():
+    lf.reset_skip_tracker()
+    yield
+    lf.reset_skip_tracker()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> JuggleDB:
+    d = JuggleDB(db_path=str(tmp_path / "loop-fire.db"))
+    d.init_db()
+    return d
+
+
+def _template(delivery="deliver", role="researcher"):
+    return {"topics": [{
+        "id": "digest", "title": "Daily digest", "objective": "obj",
+        "delivery": delivery,
+        "tasks": [{"id": "t0", "title": "task 0", "prompt": "do the thing",
+                   "role": role, "model": "sonnet", "verify_cmd": None, "deps": []}],
+    }]}
+
+
+def _make_loop(db, *, cadence="every 5m", max_cf=3, thread_id="T-loop", next_run=PAST):
+    res = create_loop_atomic(db, template=_template(), cadence=cadence,
+                             max_consecutive_failures=max_cf)
+    loop_id = res["loop_id"]
+    # V1 create leaves thread_id NULL + next_run in the future; drive it here so a
+    # failure surfaces on a real thread and the loop is due under a fixed `now`.
+    with db._connect() as conn:
+        conn.execute("UPDATE loops SET thread_id=?, next_run=? WHERE id=?",
+                     (thread_id, next_run, loop_id))
+        conn.commit()
+    return loop_id, res
+
+
+def _set_iter_state(db, project_id, loop_id, seq, state):
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE nodes SET state=? WHERE kind='task' AND project_id=? AND id LIKE ?",
+            (state, project_id, f"{loop_id}-r{seq}-%"),
+        )
+        conn.commit()
+
+
+def _iter_task_count(db, project_id, loop_id, seq):
+    with db._connect() as conn:
+        return conn.execute(
+            "SELECT COUNT(*) FROM nodes WHERE kind='task' AND project_id=? AND id LIKE ?",
+            (project_id, f"{loop_id}-r{seq}-%"),
+        ).fetchone()[0]
+
+
+# ── CAS-safe firing ─────────────────────────────────────────────────────────────
+def test_due_loop_fires_once_per_window(db):
+    """§9 idempotent fire: a due loop instantiates the template exactly once; a
+    second tick in the SAME window does not re-fire (CAS advanced next_run)."""
+    loop_id, res = _make_loop(db)
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "verified")  # prior iteration succeeded
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+    assert _iter_task_count(db, pid, loop_id, 1) == 1  # r1 fired
+    assert db.get_loop(loop_id)["run_seq"] == 1
+
+    lf.fire_due_loops(db, SESSION, now=NOW)  # next_run now PAST+5m > NOW → not due
+    assert _iter_task_count(db, pid, loop_id, 2) == 0
+    assert db.get_loop(loop_id)["run_seq"] == 1
+
+
+def test_crash_between_fire_and_advance_no_double_fire(db):
+    """§Axis-7b: next_run CAS precedes instantiate, so a retry (the crash-recovery
+    tick) in the same window produces exactly ONE iteration — never a duplicate."""
+    loop_id, res = _make_loop(db)
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "verified")
+
+    lf.fire_due_loops(db, SESSION, now=NOW)   # fires r1, advances next_run
+    lf.fire_due_loops(db, SESSION, now=NOW)   # "retry after crash" — CAS-gated no-op
+
+    assert _iter_task_count(db, pid, loop_id, 1) == 1
+    assert _iter_task_count(db, pid, loop_id, 2) == 0
+    assert db.get_loop(loop_id)["run_seq"] == 1  # advanced exactly once
+
+
+def test_cas_advance_loses_race_skips(db):
+    """CAS correctness (cas_state precedent): once next_run is advanced off the
+    expected value, a second advance with the same expected loses (rowcount 0)."""
+    loop_id, _ = _make_loop(db)
+    assert db.advance_next_run_cas(loop_id, expected=PAST, new="2020-01-01T00:05:00+00:00") == 1
+    assert db.advance_next_run_cas(loop_id, expected=PAST, new="2020-01-01T00:10:00+00:00") == 0
+    assert db.get_loop(loop_id)["next_run"] == "2020-01-01T00:05:00+00:00"
+
+
+# ── Overlap policy ──────────────────────────────────────────────────────────────
+def test_overlap_skip_when_prior_iteration_in_flight(db):
+    """§9 overlap: prior iteration un-terminal → this fire is SKIPPED (no new
+    iteration instantiated) and logged."""
+    loop_id, res = _make_loop(db)
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "running")  # prior still in flight
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+    assert _iter_task_count(db, pid, loop_id, 1) == 0  # nothing fired
+    assert db.get_loop(loop_id)["run_seq"] == 0
+
+
+def test_overlap_skip_escalates_after_k(db):
+    """§Axis-2 Objection B: K consecutive overlap-skips ESCALATE (orchestrator
+    push) — a wedged iteration surfaces, never silently killing the loop."""
+    loop_id, res = _make_loop(db)
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "running")  # permanently in flight
+
+    k = lf.max_skips()
+    for _ in range(k):
+        # re-arm next_run to PAST each window so it stays due and keeps skipping
+        with db._connect() as conn:
+            conn.execute("UPDATE loops SET next_run=? WHERE id=?", (PAST, loop_id))
+            conn.commit()
+        lf.fire_due_loops(db, SESSION, now=NOW)
+
+    pushed = [n for n in db.get_notifications_for_session(SESSION)
+              if n["message"] and "wedged" in n["message"].lower()]
+    assert pushed, "K overlap-skips must emit an escalation event"
+    assert _iter_task_count(db, pid, loop_id, 1) == 0  # still never fired
+
+
+# ── Never-swallow failure surfacing (LOAD-BEARING) ──────────────────────────────
+def test_single_iteration_failure_surfaces_all_three_never_swallowed(db):
+    """User directive 2026-07-04: a SINGLE failed iteration surfaces ALL THREE and
+    swallows NONE — (a) notifications_v2 event with the ACTUAL non-empty error,
+    (b) HIGH action item on the loop's thread, (c) orchestrator-routed
+    LOOP_ITERATION_FAILED push."""
+    loop_id, res = _make_loop(db, thread_id="T-fail")
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "failed-verify")  # prior iteration failed
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+
+    # (a)+(c): a notifications_v2 LOOP_ITERATION_FAILED event, orchestrator-routed,
+    # carrying non-empty error text naming the failed node/state.
+    notifs = db.get_notifications_for_session(SESSION)
+    failed_ev = [n for n in notifs if "failed-verify" in (n["message"] or "")]
+    assert failed_ev, "iteration failure must emit a notification carrying the error"
+    ev = failed_ev[0]
+    assert ev["message"].strip(), "error text must be NON-EMPTY (never swallowed)"
+    assert ek.handled_by_for_kind(ek.LOOP_ITERATION_FAILED) == "orchestrator"
+    with db._connect() as conn:
+        row = conn.execute(
+            "SELECT kind, handled_by FROM notifications_v2 WHERE id=?", (ev["id"],)
+        ).fetchone()
+    assert row[0] == ek.LOOP_ITERATION_FAILED
+    assert row[1] == "orchestrator"  # pushed to the orchestrator, not DB-row-only
+
+    # (b): a HIGH action item on the loop's thread.
+    items = [i for i in db.get_open_action_items() if i["thread_id"] == "T-fail"]
+    assert items, "a HIGH action item must be filed on the loop's thread"
+    assert items[0]["priority"] == "high"
+    assert items[0]["message"].strip()
+
+
+def test_repeated_failure_action_item_deduped(db):
+    """Repeated failure stays VISIBLE without flooding: N failing iterations file
+    ONE open HIGH action item (add_action_item_once dedup) while STILL re-pushing
+    the orchestrator each time."""
+    loop_id, res = _make_loop(db, thread_id="T-dedup", max_cf=99)
+    pid = res["project_id"]
+
+    _set_iter_state(db, pid, loop_id, 0, "failed-verify")
+    lf.fire_due_loops(db, SESSION, now=NOW)  # cycle 1 — fires r1
+    _set_iter_state(db, pid, loop_id, 1, "failed-verify")
+    with db._connect() as conn:
+        conn.execute("UPDATE loops SET next_run=? WHERE id=?", (PAST, loop_id))
+        conn.commit()
+    lf.fire_due_loops(db, SESSION, now=NOW)  # cycle 2 — sees r1 failed
+
+    items = [i for i in db.get_open_action_items() if i["thread_id"] == "T-dedup"]
+    assert len(items) == 1, "repeated failure must not stack duplicate HIGH items"
+    notifs = [n for n in db.get_notifications_for_session(SESSION)
+              if "failed-verify" in (n["message"] or "")]
+    assert len(notifs) >= 2, "each failure still re-pushes the orchestrator"
+
+
+# ── Circuit breaker ─────────────────────────────────────────────────────────────
+def test_circuit_breaker_pauses_after_n_failures(db):
+    """§10b runaway control: N=2 consecutive failed iterations pause the loop +
+    escalate (layered ON TOP of the per-failure surfacing)."""
+    loop_id, res = _make_loop(db, thread_id="T-brk", max_cf=2)
+    pid = res["project_id"]
+
+    _set_iter_state(db, pid, loop_id, 0, "failed-verify")
+    lf.fire_due_loops(db, SESSION, now=NOW)  # failure #1 → bump to 1, fires r1
+    assert db.get_loop(loop_id)["status"] == "active"
+
+    _set_iter_state(db, pid, loop_id, 1, "failed-verify")
+    with db._connect() as conn:
+        conn.execute("UPDATE loops SET next_run=? WHERE id=?", (PAST, loop_id))
+        conn.commit()
+    lf.fire_due_loops(db, SESSION, now=NOW)  # failure #2 → trips breaker
+
+    loop = db.get_loop(loop_id)
+    assert loop["status"] == "paused"
+    assert loop["consecutive_failures"] >= 2
+    paused_ev = [n for n in db.get_notifications_for_session(SESSION)
+                 if "pause" in (n["message"] or "").lower()]
+    assert paused_ev, "breaker trip must escalate a LOOP_PAUSED event"
+
+
+def test_successful_iteration_resets_failure_counter(db):
+    """Breaker trips on CONSECUTIVE failures only: a good iteration resets the
+    consecutive-failure counter."""
+    loop_id, res = _make_loop(db, thread_id="T-reset", max_cf=3)
+    pid = res["project_id"]
+
+    _set_iter_state(db, pid, loop_id, 0, "failed-verify")
+    lf.fire_due_loops(db, SESSION, now=NOW)  # failure #1 → counter 1, fires r1
+    assert db.get_loop(loop_id)["consecutive_failures"] == 1
+
+    _set_iter_state(db, pid, loop_id, 1, "verified")  # r1 succeeds
+    with db._connect() as conn:
+        conn.execute("UPDATE loops SET next_run=? WHERE id=?", (PAST, loop_id))
+        conn.commit()
+    lf.fire_due_loops(db, SESSION, now=NOW)  # success → resets
+
+    assert db.get_loop(loop_id)["consecutive_failures"] == 0
+
+
+def test_paused_loop_does_not_fire(db):
+    """A paused loop is inert: fire_due_loops skips it entirely (list_active_loops
+    excludes non-active)."""
+    loop_id, res = _make_loop(db)
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "verified")
+    db.set_loop_status(loop_id, "paused")
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+    assert _iter_task_count(db, pid, loop_id, 1) == 0
+    assert db.get_loop(loop_id)["run_seq"] == 0
+
+
+def test_no_due_loops_is_a_noop(db):
+    """Regression pin: a tick with NO due loop makes zero writes — a not-yet-due
+    active loop is left untouched (preserves non-loop tick behavior)."""
+    loop_id, res = _make_loop(db, next_run="2999-01-01T00:00:00+00:00")
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "verified")
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+    assert _iter_task_count(db, pid, loop_id, 1) == 0
+    assert db.get_loop(loop_id)["run_seq"] == 0
+    assert db.get_notifications_for_session(SESSION) == []

--- a/tests/test_loop_fire.py
+++ b/tests/test_loop_fire.py
@@ -266,6 +266,32 @@ def test_successful_iteration_resets_failure_counter(db):
     assert db.get_loop(loop_id)["consecutive_failures"] == 0
 
 
+def test_failed_instantiate_rolls_back_seq_bump_and_surfaces(db, monkeypatch):
+    """code-review #2 + #1 (2026-07-04): a failed instantiation rolls the run_seq
+    bump back (NO phantom empty iteration — an empty seq would read as a false
+    'success' next window, silently resetting the breaker + masking the failure)
+    AND the machinery error is surfaced through the never-swallow choke point, never
+    reduced to a log line."""
+    loop_id, res = _make_loop(db, thread_id="T-mach")
+    pid = res["project_id"]
+    _set_iter_state(db, pid, loop_id, 0, "verified")  # prior success → would fire r1
+
+    def _boom(*a, **k):
+        raise RuntimeError("injected instantiate failure")
+    monkeypatch.setattr(lf, "instantiate_topic", _boom)
+
+    lf.fire_due_loops(db, SESSION, now=NOW)
+
+    loop = db.get_loop(loop_id)
+    assert loop["run_seq"] == 0, "seq bump must roll back with the failed instantiate"
+    assert _iter_task_count(db, pid, loop_id, 1) == 0, "no phantom r1 nodes"
+    notifs = [n for n in db.get_notifications_for_session(SESSION)
+              if "machinery error" in (n["message"] or "")]
+    assert notifs, "machinery error must push the orchestrator (never swallowed)"
+    items = [i for i in db.get_open_action_items() if i["thread_id"] == "T-mach"]
+    assert items and items[0]["priority"] == "high"
+
+
 def test_paused_loop_does_not_fire(db):
     """A paused loop is inert: fire_due_loops skips it entirely (list_active_loops
     excludes non-active)."""

--- a/tests/test_loops_schema.py
+++ b/tests/test_loops_schema.py
@@ -1,0 +1,237 @@
+"""Phase-1 schema pins — loops table, projects.kind, nodes.role/delivery, run-seq.
+
+Loop-entity V1 (plan 2026-07-04). Every column defaults to CURRENT behavior so
+existing graphs/projects are byte-for-byte unchanged:
+  - nodes.role     DEFAULT 'coder'   (existing tasks still dispatch coder)
+  - nodes.delivery DEFAULT 'merge'   (existing topics still route merge→verified)
+  - projects.kind  DEFAULT 'project' (existing projects unaffected)
+
+The loops table + run_seq carry the loop entity and the atomic id-namespacing
+counter (guards the guarded-upsert collision, critique Axis-2 Objection A).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from juggle_db import JuggleDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = JuggleDB(db_path=str(tmp_path / "loops-schema.db"))
+    d.init_db()
+    return d
+
+
+def _mk_project(db) -> str:
+    return db.create_project(name="P", objective="o")
+
+
+# ── Defaults preserve current behavior ───────────────────────────────────────
+
+def test_nodes_role_defaults_coder(db):
+    """A node inserted with no role reads 'coder' (spec §4.3 default — zero
+    change for existing graphs)."""
+    from dbops.db_graph import create_task
+
+    pid = _mk_project(db)
+    create_task(db, task_id="t1", project_id=pid, title="T", prompt="p")
+    with db._connect() as conn:
+        row = conn.execute("SELECT role FROM nodes WHERE id='t1'").fetchone()
+    assert row["role"] == "coder"
+
+
+def test_nodes_delivery_defaults_merge(db):
+    """A node inserted with no delivery reads 'merge' (existing topics still
+    route merge→verified)."""
+    from dbops.db_graph import create_task
+
+    pid = _mk_project(db)
+    create_task(db, task_id="t2", project_id=pid, title="T", prompt="p")
+    with db._connect() as conn:
+        row = conn.execute("SELECT delivery FROM nodes WHERE id='t2'").fetchone()
+    assert row["delivery"] == "merge"
+
+
+def test_existing_node_defaults_coder_merge(db):
+    """REGRESSION PIN (loop-v1 Phase 1): an existing-style node (created via the
+    unchanged create_task path, no role/delivery supplied) reads coder/merge —
+    the schema seam that keeps every legacy graph dispatching coder + routing
+    merge→verified exactly as before."""
+    from dbops.db_graph import create_task
+
+    pid = _mk_project(db)
+    create_task(db, task_id="t3", project_id=pid, title="T", prompt="p")
+    with db._connect() as conn:
+        row = conn.execute(
+            "SELECT role, delivery FROM nodes WHERE id='t3'"
+        ).fetchone()
+    assert (row["role"], row["delivery"]) == ("coder", "merge")
+
+
+def test_projects_kind_defaults_project(db):
+    """A project inserted with no kind reads 'project' (existing projects
+    unaffected — they never claim the loop code path)."""
+    pid = _mk_project(db)
+    with db._connect() as conn:
+        row = conn.execute(
+            "SELECT kind FROM projects WHERE id=?", (pid,)
+        ).fetchone()
+    assert row["kind"] == "project"
+
+
+# ── loops table CRUD + run-seq ───────────────────────────────────────────────
+
+def test_loops_table_crud(db):
+    """create/get/list_active/set_status round-trip on the loops table."""
+    pid = _mk_project(db)
+    loop_id = db.create_loop(project_id=pid, cadence="daily", next_run="2026-07-05T00:00:00+00:00")
+    assert loop_id.startswith("L")
+
+    got = db.get_loop(loop_id)
+    assert got is not None
+    assert got["project_id"] == pid
+    assert got["cadence"] == "daily"
+    assert got["status"] == "active"
+    assert got["run_seq"] == 0
+    assert got["consecutive_failures"] == 0
+    assert got["next_run"] == "2026-07-05T00:00:00+00:00"
+
+    active = db.list_active_loops()
+    assert loop_id in {loop["id"] for loop in active}
+
+    db.set_loop_status(loop_id, "paused")
+    assert db.get_loop(loop_id)["status"] == "paused"
+    assert loop_id not in {loop["id"] for loop in db.list_active_loops()}
+
+
+def test_loop_ids_are_unique_sequential(db):
+    """Allocated loop ids are distinct L-labels (mirrors project P-label wheel)."""
+    pid = _mk_project(db)
+    ids = {db.create_loop(project_id=pid, cadence="daily") for _ in range(3)}
+    assert len(ids) == 3
+    assert all(i.startswith("L") for i in ids)
+
+
+def test_run_seq_monotonic_atomic(db):
+    """advance_run_seq returns STRICTLY increasing values under repeated calls.
+
+    REGRESSION PIN (critique Axis-2 Objection A, BLOCKER-adjacent): the run-seq
+    is the id-namespace that keeps a re-fired loop iteration's node ids from
+    colliding with the guarded-upsert refusal (juggle_graph_load.py:71-89).
+    A non-monotonic counter would let two iterations mint the same id."""
+    pid = _mk_project(db)
+    loop_id = db.create_loop(project_id=pid, cadence="daily")
+    seen = [db.advance_run_seq(loop_id) for _ in range(5)]
+    assert seen == sorted(seen)
+    assert len(set(seen)) == len(seen)  # all distinct
+    assert seen[0] < seen[-1]  # strictly increasing overall
+    # persisted
+    assert db.get_loop(loop_id)["run_seq"] == seen[-1]
+
+
+def test_stamp_last_run(db):
+    """stamp_last_run records the iteration timestamp."""
+    pid = _mk_project(db)
+    loop_id = db.create_loop(project_id=pid, cadence="daily")
+    assert db.get_loop(loop_id)["last_run_at"] is None
+    db.stamp_last_run(loop_id, "2026-07-04T12:00:00+00:00")
+    assert db.get_loop(loop_id)["last_run_at"] == "2026-07-04T12:00:00+00:00"
+
+
+# ── migration idempotency + fresh/migrated parity ────────────────────────────
+
+def test_migration_72_idempotent_reapply():
+    """Applying the node/project column migration twice is a no-op (additive
+    convention; mirrors migration 70/71 fail-soft)."""
+    from dbops.migration_72_node_role_delivery import migrate_72_node_role_delivery
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, title TEXT, "
+        "state TEXT, created_at TEXT, updated_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, "
+        "created_at TEXT, last_active TEXT)"
+    )
+    conn.commit()
+
+    migrate_72_node_role_delivery(conn)
+    migrate_72_node_role_delivery(conn)  # must not raise on re-run
+
+    ncols = {r[1] for r in conn.execute("PRAGMA table_info(nodes)")}
+    pcols = {r[1] for r in conn.execute("PRAGMA table_info(projects)")}
+    assert {"role", "delivery"} <= ncols
+    assert "kind" in pcols
+
+
+def test_migration_72_defaults_applied_on_alter():
+    """The ALTER path (already-migrated DB) also yields coder/merge/project — a
+    pre-existing node/project row reads the new-column defaults after migrate."""
+    from dbops.migration_72_node_role_delivery import migrate_72_node_role_delivery
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE nodes (id TEXT PRIMARY KEY, kind TEXT, title TEXT, "
+        "state TEXT, created_at TEXT, updated_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, "
+        "created_at TEXT, last_active TEXT)"
+    )
+    conn.execute("INSERT INTO nodes(id, kind) VALUES ('n1', 'task')")
+    conn.execute("INSERT INTO projects(id, name) VALUES ('P1', 'x')")
+    conn.commit()
+
+    migrate_72_node_role_delivery(conn)
+
+    n = conn.execute("SELECT role, delivery FROM nodes WHERE id='n1'").fetchone()
+    p = conn.execute("SELECT kind FROM projects WHERE id='P1'").fetchone()
+    assert (n["role"], n["delivery"]) == ("coder", "merge")
+    assert p["kind"] == "project"
+
+
+def test_migration_73_loops_idempotent_reapply():
+    """Applying the loops-table migration twice is a no-op (CREATE TABLE IF NOT
+    EXISTS; mirrors migration 70/71 fail-soft)."""
+    from dbops.migration_73_loops import migrate_73_loops
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, "
+        "created_at TEXT, last_active TEXT)"
+    )
+    conn.commit()
+
+    migrate_73_loops(conn)
+    migrate_73_loops(conn)  # must not raise on re-run
+
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "loops" in tables
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(loops)")}
+    assert {"run_seq", "consecutive_failures", "max_consecutive_failures",
+            "status", "next_run", "last_run_at", "cadence"} <= cols
+
+
+def test_fresh_init_has_all_phase1_schema(db):
+    """A fresh `db init` (DDL, no ALTER path) already carries every Phase-1
+    column/table — fresh vs migrated parity."""
+    with db._connect() as conn:
+        ncols = {r[1] for r in conn.execute("PRAGMA table_info(nodes)")}
+        pcols = {r[1] for r in conn.execute("PRAGMA table_info(projects)")}
+        tables = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"role", "delivery"} <= ncols
+    assert "kind" in pcols
+    assert "loops" in tables

--- a/tests/test_terminal_states.py
+++ b/tests/test_terminal_states.py
@@ -7,6 +7,18 @@ ZERO behaviour change. Each pin below freezes ONE migrated site's exact
 pre-Phase-0 membership AND asserts the site now references the canonical object,
 so the consolidation is provably behaviour-neutral and Phase 3's `delivered`
 success-terminal becomes a single-line, test-guarded edit.
+
+PHASE 3 UPDATE (2026-07-04, loop-entity V1): `delivered` was added to
+TERMINAL_SUCCESS_STATES. Every set composed from that atom (the eight below
+marked "+delivered") now INTENTIONALLY includes it — this is the reviewed,
+behaviour-changing pin edit the regression-pin gate allows: `delivered` is a
+second success-terminal that must be accepted everywhere `verified` is treated
+as terminal-success (completion gate, guarded-upsert protection, tick-ownership,
+reopen-before-add-task, replay supersede, reconcile/frontier/plan done-rollup,
+topic-done derivation, cockpit done-glyph). The sets NOT composed from
+TERMINAL_SUCCESS_STATES (IN_FLIGHT_STATES inverse, NON_TERMINAL_DISPLAY_STATUSES)
+are unchanged — `delivered` is terminal, so it is correctly absent from both, and
+the merged_sha GATE (graph_guards.topic_is_merged) stays verified-only.
 """
 from __future__ import annotations
 
@@ -24,8 +36,8 @@ def test_task_terminal_membership_unchanged():
     import juggle_cmd_agents_graph_topics as m
 
     expected = frozenset(
-        {"verified", "failed-exec", "failed-integration", "failed-verify",
-         "blocked-failed", "cancelled"}
+        {"verified", "delivered", "failed-exec", "failed-integration",
+         "failed-verify", "blocked-failed", "cancelled"}  # +delivered (Phase 3)
     )
     assert ts.TASK_TERMINAL_STATES == expected
     assert m._TASK_TERMINAL is ts.TASK_TERMINAL_STATES
@@ -36,7 +48,8 @@ def test_protected_states_membership_unchanged():
     touch a task in one of these."""
     from dbops import db_graph
 
-    expected = frozenset({"dispatching", "running", "integrating", "verified"})
+    expected = frozenset({"dispatching", "running", "integrating", "verified",
+                          "delivered"})  # +delivered (Phase 3): don't clobber it
     assert ts.PROTECTED_STATES == expected
     assert db_graph.PROTECTED_STATES is ts.PROTECTED_STATES
 
@@ -47,7 +60,8 @@ def test_tick_owned_states_membership_unchanged():
     from dbops import db_graph
 
     expected = frozenset(
-        {"ready", "dispatching", "running", "integrating", "verified"}
+        {"ready", "dispatching", "running", "integrating", "verified",
+         "delivered"}  # +delivered (Phase 3): tick owns the deliver terminal too
     )
     assert ts.TICK_OWNED_STATES == expected
     assert db_graph.TICK_OWNED_STATES is ts.TICK_OWNED_STATES
@@ -59,8 +73,8 @@ def test_terminal_reopen_topic_states_unchanged():
     import juggle_graph_add as m
 
     expected = frozenset(
-        {"verified", "failed-exec", "failed-integration", "failed-verify",
-         "blocked-failed", "integrated-unlanded"}
+        {"verified", "delivered", "failed-exec", "failed-integration",
+         "failed-verify", "blocked-failed", "integrated-unlanded"}  # +delivered
     )
     assert ts.TERMINAL_REOPEN_TOPIC_STATES == expected
     assert m.TERMINAL_REOPEN_TOPIC_STATES is ts.TERMINAL_REOPEN_TOPIC_STATES
@@ -70,7 +84,7 @@ def test_success_terminal_membership_unchanged():
     """juggle_spool_apply._SUCCESS_TERMINAL — spool replay/supersede success set."""
     import juggle_spool_apply as m
 
-    expected = frozenset({"verified", "integrated-unlanded"})
+    expected = frozenset({"verified", "delivered", "integrated-unlanded"})  # +delivered
     assert ts.SUCCESS_REPLAY_TERMINAL_STATES == expected
     assert m._SUCCESS_TERMINAL is ts.SUCCESS_REPLAY_TERMINAL_STATES
 
@@ -80,7 +94,7 @@ def test_completion_task_states_unchanged():
     from dbops import db_topics  # noqa: F401  parent must load first (import-order)
     from dbops import db_topics_reconcile as m
 
-    expected = frozenset({"verified", "cancelled"})
+    expected = frozenset({"verified", "delivered", "cancelled"})  # +delivered (Phase 3)
     assert ts.COMPLETION_TERMINAL_STATES == expected
     assert m._COMPLETION_TASK_STATES is ts.COMPLETION_TERMINAL_STATES
 
@@ -89,7 +103,7 @@ def test_merged_terminal_unchanged():
     """juggle_topic_derive._MERGED_TERMINAL — topic-done derivation set."""
     import juggle_topic_derive as m
 
-    expected = frozenset({"verified", "done", "cancelled"})
+    expected = frozenset({"verified", "delivered", "done", "cancelled"})  # +delivered
     assert ts.MERGED_TERMINAL_STATES == expected
     assert m._MERGED_TERMINAL is ts.MERGED_TERMINAL_STATES
 
@@ -98,7 +112,7 @@ def test_cockpit_merged_unchanged():
     """juggle_cockpit_tree._MERGED — cockpit tree done-glyph rollup set."""
     import juggle_cockpit_tree as m
 
-    expected = frozenset({"verified", "done"})
+    expected = frozenset({"verified", "delivered", "done"})  # +delivered (Phase 3)
     assert ts.MERGED_DONE_STATES == expected
     assert m._MERGED is ts.MERGED_DONE_STATES
 
@@ -110,7 +124,7 @@ def test_done_states_both_defs_unchanged():
     import juggle_frontier_layout as fl
     import juggle_plan_layout as pl
 
-    expected = frozenset({"verified", "cancelled"})
+    expected = frozenset({"verified", "delivered", "cancelled"})  # +delivered (Phase 3)
     assert frozenset(fl.DONE_STATES) == expected
     assert frozenset(pl.DONE_STATES) == expected
     assert fl.DONE_STATES is pl.DONE_STATES


### PR DESCRIPTION
## Loop Entity — V1 (recurring scheduled agent work)

Data-declared **loop** = a recurring scheduler that fires on a cadence via the watchdog tick, creates its own `kind='loop'` project + single-topic graph, and runs it through the existing agent pool. Continuation of the parked 2026-07-03 loop-engineering discussion.

**Design + provenance:** spec `docs/2026-07-04-loop-entity-spec.md`, DA critique `…-spec-critique.md`, plan `plan/2026-07-04-loop-entity-v1-plan.md`, five facts docs under `research/` (all in the vault).

Restore point before this work: tag `pre-loop-engineering` (`e1dafc2`).

### Why a PR (not ff-merge)
Adds DB migrations (72, 73) **and** touches the verify state machine (new `delivered` terminal) — both triggers in the repo landing policy.

### Phases (each landed green independently, TDD)
- **Phase 0** *(already on main, `cca4137`)* — canonical `terminal_states.py` consolidating ~14 scattered `verified`-terminal definitions, membership-pinned. Precursor refactor.
- **Phase 1** — schema: `loops` table, `projects.kind`, `nodes.role`/`nodes.delivery`, `run_seq` (defaults preserve all existing behavior).
- **Phase 2** — per-node role dispatch (researcher gets no worktree; coder/planner unchanged).
- **Phase 3** — `delivered` success-terminal for non-merge work. **`verified ⟺ merged` left pristine** — the merged_sha gate is deliberately not composed from the success set; exhaustive consumer audit.
- **Phase 4** — transactional `/juggle:schedule:create` router (OS-schedule vs loop) + atomic loop-create with rollback + deterministic partition validator; `kind='loop'` excluded from P-slots.
- **Phase 5** — CAS-safe watchdog firing (no double-fire on crash), overlap-skip/escalate, failure circuit-breaker, and a **never-swallow** `surface_iteration_failure` choke point → notification + HIGH action item + `LOOP_ITERATION_FAILED` orchestrator push.
- **Fix** — loops bound to their own thread so failures surface in the action pane on the loop, not the orphan bucket.

### Invariant safety
- `verified ⟺ merged` unchanged (pinned: `test_merge_topic_still_requires_merged_sha`).
- Non-loop projects/topics behave identically (defaults `coder`/`merge`, regression-pinned).
- Migration numbers reserved atomically via `migration next` (dodged a stale-counter collision with existing migration 71).

### Verification
Full suite **4027 passed / 7 skipped**; `doctor --dry-run` clean; ruff clean; LOC gate OK; cockpit viewport smoke (7 profiles) pass. Every bug/regression fix carries a RED-proven pin.

### Deferred to V2 (explicitly out of scope)
Cross-topic vault handoff (pointer-in-handoff), `nodes.model` + model-claim predicate + idle-TTL, Loops render band, `schedule:list`/`delete`, iteration GC/compaction depth, anti-starvation tuning. The loop's `model` field is validated but not yet persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
