### PR TITLE
autofix: 2026-07-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-07-05 (autofix)
+- **feat(loops)**: atomic reopen-regenerate + four-seam integrate reset; stable-topic create; delivered upstream satisfies cross-topic dep-readiness; watchdog CAS-safe firing + failure circuit-breaker; transactional schedule:create router + deliver completion
+- **feat(dispatch)**: general per-node model persist + best-effort headroom preference; per-node role dispatch (researcher gets no worktree)
+- **feat(states)**: delivered success-terminal state (deliver→delivered, no merged_sha)
+- **feat(schedule)**: one schedule namespace — :list/:delete verbs + shared OS-backend doc
+- **fix(loops)**: fail loud when stable topic is not fire-ready; bind created loop to its own thread; never-swallow fire-machinery errors + atomic seq-bump/instantiate; address Phase-4 code-review findings
+- **fix(schedule)**: surface OS-backend enumeration errors on delete
+
 ## 2026-07-01 (v1.93.0)
 - **feat(selfheal): verify-fallback — bounded retry with fresh context**: a graph task whose real `verify_cmd` is red no longer escalates on the first failure. It routes through `juggle_verify_fallback.on_failed_verify`, which — while `verify_retries < N` (config `verify_fallback_retries` / env `JUGGLE_VERIFY_FALLBACK_RETRIES`, default 1) — increments the counter, stores the prior verify failure output, and resets the task to `ready` so the watchdog tick re-dispatches a FRESH agent with that failure injected into its prompt. The tick re-runs the REAL `verify_cmd` exactly as before (safety rail: no verdict CLI, no evidence artifact, no rubber-stamp). On exhaustion the task stays `failed-verify` and escalates via the same HIGH action item as any terminal failure. New `nodes.verify_retries`/`nodes.verify_failure` columns (Migration 57, additive).
 

--- a/src/juggle_cmd_agents_common.py
+++ b/src/juggle_cmd_agents_common.py
@@ -18,15 +18,20 @@ single patch surface for the whole juggle_cmd_agents_* family.
 import re
 
 from juggle_cli_common import (
+    SRC_DIR,                # noqa: F401 — re-exported for sub-module use
     _get_hindsight_client,  # noqa: F401 — re-exported for sub-module use
-    _last_sentences,        # noqa: F401
-    )
+    _last_sentences,        # noqa: F401 — re-exported for sub-module use
+    _resolve_thread,        # noqa: F401 — re-exported for sub-module use
+    get_db,                 # noqa: F401 — re-exported for sub-module use
+)
 import juggle_cmd_integrate  # noqa: F401 — imported here so sub-modules can access via _com
 from juggle_cmd_agents_worktree import (  # noqa: F401 — re-exported patch surface
     _create_worktree,
     _finalize_worktree,
 )
+from juggle_harness import get_adapter  # noqa: F401 — re-exported for sub-module use
 from juggle_settings import get_settings as _get_settings
+from juggle_tmux import JuggleTmuxManager  # noqa: F401 — re-exported for sub-module use
 
 _AGENT_TTL_SECS: int = _get_settings()["agent_idle_ttl_secs"]
 

--- a/src/juggle_cmd_agents_common.py
+++ b/src/juggle_cmd_agents_common.py
@@ -18,20 +18,15 @@ single patch surface for the whole juggle_cmd_agents_* family.
 import re
 
 from juggle_cli_common import (
-    SRC_DIR,
     _get_hindsight_client,  # noqa: F401 — re-exported for sub-module use
     _last_sentences,        # noqa: F401
-    _resolve_thread,
-    get_db,
-)
+    )
 import juggle_cmd_integrate  # noqa: F401 — imported here so sub-modules can access via _com
 from juggle_cmd_agents_worktree import (  # noqa: F401 — re-exported patch surface
     _create_worktree,
     _finalize_worktree,
 )
-from juggle_harness import get_adapter
 from juggle_settings import get_settings as _get_settings
-from juggle_tmux import JuggleTmuxManager
 
 _AGENT_TTL_SECS: int = _get_settings()["agent_idle_ttl_secs"]
 

--- a/src/juggle_cmd_projects.py
+++ b/src/juggle_cmd_projects.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import math
-import os
 import re as _re
 import subprocess
 import sys
@@ -14,7 +13,7 @@ from pathlib import Path
 SRC_DIR = Path(__file__).parent
 sys.path.insert(0, str(SRC_DIR))
 
-from juggle_cli_common import _cheap_llm_call, get_db, llm_call
+from juggle_cli_common import get_db, llm_call
 
 INBOX_PROJECT_ID = "INBOX"
 log = logging.getLogger(__name__)

--- a/src/juggle_cockpit.py
+++ b/src/juggle_cockpit.py
@@ -18,6 +18,7 @@ import os
 import signal
 import subprocess
 import sys
+import time  # noqa: F401 - patch target for test_cockpit_profile
 from pathlib import Path
 
 SRC_DIR = Path(__file__).parent

--- a/src/juggle_cockpit.py
+++ b/src/juggle_cockpit.py
@@ -32,11 +32,13 @@ from textual.widgets import Footer, Header, Static
 from juggle_db import JuggleDB
 from juggle_settings import get_settings as _get_settings
 from juggle_cockpit_helpers import (
+    _PRIORITY_TIER_MAP,  # noqa: F401 — re-exported; tests import from juggle_cockpit
     _SCROLL_PANES,
     _apply_filter_actions,
     _apply_filter_text,
     _new_blocker_actions,
     _newly_failed_agents,
+    _parse_filter,       # noqa: F401 — re-exported; tests import from juggle_cockpit
     _resolve_actions_by_thread_label,
     _resolve_agent_by_index,
     _resolve_thread_by_label,

--- a/src/juggle_cockpit.py
+++ b/src/juggle_cockpit.py
@@ -14,12 +14,10 @@ Exit: q or Ctrl-C
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import signal
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 SRC_DIR = Path(__file__).parent
@@ -34,13 +32,11 @@ from textual.widgets import Footer, Header, Static
 from juggle_db import JuggleDB
 from juggle_settings import get_settings as _get_settings
 from juggle_cockpit_helpers import (
-    _PRIORITY_TIER_MAP,
     _SCROLL_PANES,
     _apply_filter_actions,
     _apply_filter_text,
     _new_blocker_actions,
     _newly_failed_agents,
-    _parse_filter,
     _resolve_actions_by_thread_label,
     _resolve_agent_by_index,
     _resolve_thread_by_label,

--- a/src/juggle_cockpit_profile.py
+++ b/src/juggle_cockpit_profile.py
@@ -119,7 +119,6 @@ def run_profile(duration: int = 60, db_path: str | None = None) -> None:
     Degrades gracefully if ``uvx``/``psrecord`` are unavailable — exits 0 with
     a clear message so CI is not broken.
     """
-    import os as _os
 
     log_path = Path("/tmp/cockpit_profile.log")
     plot_path = Path("/tmp/cockpit_profile.png")

--- a/src/juggle_cockpit_screenshot.py
+++ b/src/juggle_cockpit_screenshot.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sqlite3
 import sys
 
 

--- a/src/juggle_context.py
+++ b/src/juggle_context.py
@@ -4,8 +4,7 @@
 import os
 import re
 
-from juggle_cli_common import _humanize_dt, _extract_decision_prompt
-from juggle_db import JuggleDB, _is_junk_message, _thread_age_seconds
+from juggle_db import JuggleDB
 from juggle_settings import get_settings as _get_settings
 
 from juggle_context_startup import (  # noqa: F401 — re-exported public API

--- a/src/juggle_context_startup.py
+++ b/src/juggle_context_startup.py
@@ -7,7 +7,6 @@ Must not own: the UserPromptSubmit additionalContext builder (juggle_context).
 All names are re-exported from juggle_context for backward compatibility.
 """
 
-import re
 
 from juggle_cli_common import _humanize_dt, _extract_decision_prompt
 from juggle_db import JuggleDB, _is_junk_message, _thread_age_seconds

--- a/src/juggle_hooks_checkpoint.py
+++ b/src/juggle_hooks_checkpoint.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import sys
-from pathlib import Path
 
 import juggle_hooks_config as _cfg
 

--- a/src/juggle_hooks_config.py
+++ b/src/juggle_hooks_config.py
@@ -6,10 +6,7 @@ Owns: DB_PATH, _CHECKPOINT_PATH, AUTOPILOT_FLAG, logging setup, is_active(),
 Must not own: handler logic, event routing.
 """
 
-import json
 import logging
-import os
-import threading
 from pathlib import Path
 
 from juggle_db import JuggleDB

--- a/src/juggle_monitor_daemon.py
+++ b/src/juggle_monitor_daemon.py
@@ -192,7 +192,7 @@ def _load_cursor(cursor_path: Path, db_path: Path) -> int:
         return baseline
 
 
-def _handle_term(signum, frame) -> None:
+def _handle_term(_signum, frame) -> None:
     """Clean, idempotent shutdown for SIGTERM/SIGINT.
 
     atexit does NOT run on SIGTERM (Python terminates immediately, exit 143),

--- a/src/juggle_watchdog_daemon.py
+++ b/src/juggle_watchdog_daemon.py
@@ -159,11 +159,11 @@ _stall_tracker = _StallTracker()
 _tick_event = threading.Event()
 
 
-def _handle_sigusr1(signum, frame):
+def _handle_sigusr1(_signum, frame):
     _tick_event.set()  # idempotent; coalesces multiple concurrent signals
 
 
-def _handle_sigterm(signum, frame):
+def _handle_sigterm(_signum, frame):
     global _running
     _log.info("Watchdog: SIGTERM received, shutting down")
     _running = False


### PR DESCRIPTION
## autofix: 2026-07-05

> Generated by `/schedule:autofix` via Claude Code Routines.
> Branch: `cyc_schedule-autofix-2026-07-05`
> **DO NOT MERGE** without human review — this is the human review gate per `skills/schedule-autofix/SKILL.md`.

### Summary

| Fix | Files changed | Lines +/- | Status |
|-----|--------------|-----------|--------|
| FX-1 | 9 | +3/-21 | ✅ committed (ruff F401/F841 auto-fix) |
| FX-2 | 2 | +3/-3 | ✅ committed (vulture 100% — 3 unused `signum` signal-handler params renamed to `_signum`) |
| FX-3 | 0 | — | ⚪ no findings (LLM unavailable — no ANTHROPIC_API_KEY in subprocess env) |
| FX-4 | 0 | — | ⚪ no findings (Juggle DB not initialized in this container; LLM unavailable) |
| FX-5 | 0 | — | ⚪ no findings (LLM unavailable — no ANTHROPIC_API_KEY in subprocess env) |
| FX-6 | 1 | +8/-0 | ✅ committed (CHANGELOG entry for week's 50 commits) |
| FX-7 | 0 | — | ⚠️ tool unavailable (graphify not installed in container) |

### FX-1 regression note

Ruff removed re-exported symbols from two "patch surface" modules where symbols are imported without `# noqa: F401` but are accessed by sub-modules as `_com.symbol`. Two follow-up commits restore the missing re-exports with proper `# noqa: F401` annotations:

- `juggle_cmd_agents_common`: restored `SRC_DIR`, `_resolve_thread`, `get_db`, `get_adapter`, `JuggleTmuxManager`
- `juggle_cockpit`: restored `_parse_filter`, `_PRIORITY_TIER_MAP`

The root cause is missing `# noqa: F401` on re-export-only imports. The fix is included in this PR.

### Smoke test

```
12 failed, 4044 passed, 7 skipped in 408.68s
```

All 12 failures are **pre-existing on `main`** (verified by running the same tests against the base). Zero regressions introduced by this PR.

### Related issues filed this run

- https://github.com/cyc115/juggle/issues/60 — IS-1: security finding MEDIUM SQL injection in `src/dbops/agents.py:72` (+ 7 related MEDIUM findings in dbops/)
- https://github.com/cyc115/juggle/issues/61 — IS-3: probable dead code — `get_best_agent`, `get_watchdog_events`, `bump_verify_retry`, `thread_status_to_node_state`, `is_pushable` (vulture 60%)

### Infrastructure gaps (for `schedules/autofix.py` maintainer)

- `gh` CLI is not available in this container — PR was created via GitHub MCP tools instead. The `gh_pr_list_head()` safety gate in `schedules/common.py` silently returns `[]` when `gh` is absent, bypassing the "existing PR" guard. Fix: add MCP/API fallback.
- `ANTHROPIC_API_KEY` is not exposed to subprocesses — FX-3/FX-4/FX-5 LLM sections were skipped.
- `graphify` not installed — FX-7 marked tool unavailable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q89QScA1S17pRGF6rV3thy)_